### PR TITLE
Implement persistent prompt cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ FramePack-eichiは、lllyasviel師の[lllyasviel/FramePack](https://github.com/l
 - **LoRA機能の強化**: 3つのLoRAの同時使用に対応、/webui/loraフォルダからの選択機能　※v1.9.2で追加
 - **セクション情報の一括管理**: ZIPファイルによるセクション情報のダウンロード/アップロードと内容変更後の再ダウンロードに対応　※v1.9.2で追加
 - **VAEキャッシュ機能**: フレーム単位のデコードによる処理速度向上（オプション）　※v1.9.2で追加、[furusu氏の検証](https://note.com/gcem156/n/nb93535d80c82)と[FramePack実装](https://github.com/laksjdjf/FramePack)に基づく
+- **プロンプトキャッシュ機能**: プロンプト解析結果をMD5ハッシュで保存し、同一プロンプトでは再解析を省略　※v1.9.5で追加
 - **FP8最適化**: LoRA適用時のVRAM使用量削減と処理速度の最適化　※v1.9.1で追加
 - **LoRAプリセットマネージャー**: 複数のLoRA設定の保存・読み込み機能　※v1.9.3で追加
 - **動画生成時間の拡張**: eichi(無印)に30秒、40秒を追加、F1に30秒、40秒、60秒、120秒を追加　※v1.9.3で追加
@@ -425,6 +426,7 @@ RTX 50シリーズ（RTX 5070Ti、RTX 5080、RTX 5090など）では特別なセ
      - `tensor_processing.py` - テンソル処理機能 ※v1.9.4で追加
      - `tensor_tool.py` - テンソルツール（eichi用） ※v1.9.4で追加
      - `tensor_tool_f1.py` - テンソルツール（F1用） ※v1.9.4で追加
+     - `prompt_cache.py` - プロンプトキャッシュモジュール ※v1.9.5で追加
    - `lora_utils` フォルダ - LoRA関連モジュール
      - `__init__.py`
      - `dynamic_swap_lora.py` - LoRA管理モジュール（後方互換性用に維持）

--- a/webui/eichi_utils/preset_manager.py
+++ b/webui/eichi_utils/preset_manager.py
@@ -7,6 +7,7 @@ import os
 import json
 import traceback
 from datetime import datetime
+from . import prompt_cache
 
 from locales.i18n_extended import translate
 
@@ -50,7 +51,8 @@ def initialize_presets():
                     "prompt": default_startup_prompt,
                     "timestamp": datetime.now().isoformat(),
                     "is_default": True,
-                    "is_startup_default": True
+                    "is_startup_default": True,
+                    "prompt_hash": prompt_cache.prompt_hash(default_startup_prompt, "")
                 })
                 presets_data["default_startup_prompt"] = default_startup_prompt
 
@@ -73,7 +75,8 @@ def initialize_presets():
             "name": translate("デフォルト {i}: {prompt_text}...").format(i=i+1, prompt_text=prompt_text[:20]),
             "prompt": prompt_text,
             "timestamp": datetime.now().isoformat(),
-            "is_default": True
+            "is_default": True,
+            "prompt_hash": prompt_cache.prompt_hash(prompt_text, "")
         })
 
     # 起動時デフォルトプリセットを追加
@@ -82,7 +85,8 @@ def initialize_presets():
         "prompt": default_startup_prompt,
         "timestamp": datetime.now().isoformat(),
         "is_default": True,
-        "is_startup_default": True
+        "is_startup_default": True,
+        "prompt_hash": prompt_cache.prompt_hash(default_startup_prompt, "")
     })
 
     # 保存
@@ -206,6 +210,7 @@ def save_preset(name, prompt_text):
                 # 既存の起動時デフォルトを更新
                 preset["prompt"] = prompt_text
                 preset["timestamp"] = datetime.now().isoformat()
+                preset["prompt_hash"] = prompt_cache.prompt_hash(prompt_text, "")
                 startup_default_exists = True
                 # 起動時デフォルトを更新
                 break
@@ -217,7 +222,8 @@ def save_preset(name, prompt_text):
                 "prompt": prompt_text,
                 "timestamp": datetime.now().isoformat(),
                 "is_default": True,
-                "is_startup_default": True
+                "is_startup_default": True,
+                "prompt_hash": prompt_cache.prompt_hash(prompt_text, "")
             })
             print(translate("起動時デフォルトを新規作成: {0}").format(prompt_text[:50]))
 
@@ -242,6 +248,7 @@ def save_preset(name, prompt_text):
         if preset["name"] == name:
             preset["prompt"] = prompt_text
             preset["timestamp"] = datetime.now().isoformat()
+            preset["prompt_hash"] = prompt_cache.prompt_hash(prompt_text, "")
             preset_exists = True
             # 既存のプリセットを更新
             break
@@ -251,7 +258,8 @@ def save_preset(name, prompt_text):
             "name": name,
             "prompt": prompt_text,
             "timestamp": datetime.now().isoformat(),
-            "is_default": False
+            "is_default": False,
+            "prompt_hash": prompt_cache.prompt_hash(prompt_text, "")
         })
         # 新規プリセットを作成
 

--- a/webui/eichi_utils/prompt_cache.py
+++ b/webui/eichi_utils/prompt_cache.py
@@ -1,0 +1,37 @@
+import os
+import hashlib
+import torch
+
+
+def get_cache_dir():
+    """Return the directory for prompt cache files."""
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    cache_dir = os.path.join(base_dir, 'prompt_cache')
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def prompt_hash(prompt: str, n_prompt: str) -> str:
+    """Generate an MD5 hash from prompt and negative prompt."""
+    combined = f"{prompt or ''}||{n_prompt or ''}"
+    return hashlib.md5(combined.encode('utf-8')).hexdigest()
+
+
+def load_from_cache(prompt: str, n_prompt: str):
+    """Load cached tensors from disk if available."""
+    cache_file = os.path.join(get_cache_dir(), prompt_hash(prompt, n_prompt) + '.pt')
+    if os.path.exists(cache_file):
+        try:
+            return torch.load(cache_file)
+        except Exception:
+            return None
+    return None
+
+
+def save_to_cache(prompt: str, n_prompt: str, data: dict):
+    """Save tensors to disk cache."""
+    cache_file = os.path.join(get_cache_dir(), prompt_hash(prompt, n_prompt) + '.pt')
+    try:
+        torch.save(data, cache_file)
+    except Exception as e:
+        print(f"Failed to save prompt cache: {e}")


### PR DESCRIPTION
## Summary
- add prompt cache utility to store encoding tensors by MD5
- use file cache in `oneframe_ichi.py`
- store MD5 hashes in prompt presets
- mention prompt cache in README

## Testing
- `python -m py_compile webui/oneframe_ichi.py webui/eichi_utils/prompt_cache.py webui/eichi_utils/preset_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685bd97ebeb0832f8d9caf25a9cd099c