### PR TITLE
Add input image saving option

### DIFF
--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -257,8 +257,9 @@ def get_default_app_settings_oichi():
         
         # キュー設定
         "use_queue": False,
-        
+
         # 自動保存・アラーム設定
+        "save_input_images": False,
         "save_settings_on_start": False,
         "alarm_on_completion": True
     }


### PR DESCRIPTION
## Summary
- add `save_input_images` setting with UI checkbox
- store new setting in defaults and save handlers
- save selected input and reference images when option enabled

## Testing
- `python -m py_compile webui/oneframe_ichi.py webui/eichi_utils/settings_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685c836684f4832fa8758351a04e0662