### PR TITLE
Allow custom dropdown values

### DIFF
--- a/version/v1.9.3/webui/endframe_ichi.py
+++ b/version/v1.9.3/webui/endframe_ichi.py
@@ -4150,19 +4150,19 @@ with block:
                         label=translate("LoRAモデル選択 1"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown2 = gr.Dropdown(
                         label=translate("LoRAモデル選択 2"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown3 = gr.Dropdown(
                         label=translate("LoRAモデル選択 3"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     # スキャンボタン
                     lora_scan_button = gr.Button(translate("LoRAディレクトリを再スキャン"), variant="secondary")

--- a/version/v1.9.3/webui/endframe_ichi_f1.py
+++ b/version/v1.9.3/webui/endframe_ichi_f1.py
@@ -2788,19 +2788,19 @@ with block:
                         label=translate("LoRAモデル選択 1"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown2 = gr.Dropdown(
                         label=translate("LoRAモデル選択 2"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown3 = gr.Dropdown(
                         label=translate("LoRAモデル選択 3"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     # スキャンボタン
                     lora_scan_button = gr.Button(translate("LoRAディレクトリを再スキャン"), variant="secondary")

--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -3019,9 +3019,9 @@ with block:
                     with gr.Group(visible=False) as lora_dropdown_group:
                         # LoRAドロップダウン
                         none_choice = translate("なし")
-                        lora_dropdown1 = gr.Dropdown(label=translate("LoRA1"), choices=[none_choice], value=none_choice)
-                        lora_dropdown2 = gr.Dropdown(label=translate("LoRA2"), choices=[none_choice], value=none_choice)
-                        lora_dropdown3 = gr.Dropdown(label=translate("LoRA3"), choices=[none_choice], value=none_choice)
+                        lora_dropdown1 = gr.Dropdown(label=translate("LoRA1"), choices=[none_choice], value=none_choice, allow_custom_value=True)
+                        lora_dropdown2 = gr.Dropdown(label=translate("LoRA2"), choices=[none_choice], value=none_choice, allow_custom_value=True)
+                        lora_dropdown3 = gr.Dropdown(label=translate("LoRA3"), choices=[none_choice], value=none_choice, allow_custom_value=True)
                         
                         # ドロップダウン更新ボタン（下に配置）
                         lora_scan_button = gr.Button(value=translate("LoRAフォルダを再スキャン"), variant="secondary")

--- a/webui/eichi_utils/tensor_tool.py
+++ b/webui/eichi_utils/tensor_tool.py
@@ -3218,19 +3218,19 @@ with block:
                                     label=translate("LoRAモデル選択 1"),
                                     choices=[],
                                     value=None,
-                                    allow_custom_value=False,
+                                    allow_custom_value=True,
                                 )
                                 lora_dropdown2 = gr.Dropdown(
                                     label=translate("LoRAモデル選択 2"),
                                     choices=[],
                                     value=None,
-                                    allow_custom_value=False,
+                                    allow_custom_value=True,
                                 )
                                 lora_dropdown3 = gr.Dropdown(
                                     label=translate("LoRAモデル選択 3"),
                                     choices=[],
                                     value=None,
-                                    allow_custom_value=False,
+                                    allow_custom_value=True,
                                 )
                                 # スキャンボタン
                                 lora_scan_button = gr.Button(

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -4029,19 +4029,19 @@ with block:
                         label=translate("LoRAモデル選択 1"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown2 = gr.Dropdown(
                         label=translate("LoRAモデル選択 2"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown3 = gr.Dropdown(
                         label=translate("LoRAモデル選択 3"),
                         choices=initial_lora_choices,
                         value=translate("なし"),
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     # スキャンボタン
                     lora_scan_button = gr.Button(translate("LoRAディレクトリを再スキャン"), variant="secondary")

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -1085,7 +1085,7 @@ def create_enhanced_config_queue_ui():
                     label=translate("Select Config"),
                     choices=available_configs,
                     value=None,
-                    allow_custom_value=False,
+                    allow_custom_value=True,
                     info=translate("Select a config file to load, queue, or delete")
                 )
             with gr.Column(scale=1):
@@ -4927,19 +4927,19 @@ with block:
                         label=translate("LoRAモデル選択 1"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown2 = gr.Dropdown(
                         label=translate("LoRAモデル選択 2"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     lora_dropdown3 = gr.Dropdown(
                         label=translate("LoRAモデル選択 3"),
                         choices=[],
                         value=None,
-                        allow_custom_value=False
+                        allow_custom_value=True
                     )
                     # スキャンボタン
                     lora_scan_button = gr.Button(translate("LoRAディレクトリを再スキャン"), variant="secondary")

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2882,9 +2882,9 @@ with block:
                     with gr.Group(visible=False) as lora_dropdown_group:
                         # LoRAドロップダウン
                         none_choice = translate("なし")
-                        lora_dropdown1 = gr.Dropdown(label=translate("LoRA1"), choices=[none_choice], value=none_choice)
-                        lora_dropdown2 = gr.Dropdown(label=translate("LoRA2"), choices=[none_choice], value=none_choice)
-                        lora_dropdown3 = gr.Dropdown(label=translate("LoRA3"), choices=[none_choice], value=none_choice)
+                        lora_dropdown1 = gr.Dropdown(label=translate("LoRA1"), choices=[none_choice], value=none_choice, allow_custom_value=True)
+                        lora_dropdown2 = gr.Dropdown(label=translate("LoRA2"), choices=[none_choice], value=none_choice, allow_custom_value=True)
+                        lora_dropdown3 = gr.Dropdown(label=translate("LoRA3"), choices=[none_choice], value=none_choice, allow_custom_value=True)
                         
                         # ドロップダウン更新ボタン（下に配置）
                         lora_scan_button = gr.Button(value=translate("LoRAフォルダを再スキャン"), variant="secondary")


### PR DESCRIPTION
## Summary
- allow custom values in LoRA and config dropdowns

## Testing
- `grep -R "allow_custom_value=True" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_68650f054794832f818e68881832e64b