### PR TITLE
Fix folder path handling

### DIFF
--- a/webui/eichi_utils/log_manager.py
+++ b/webui/eichi_utils/log_manager.py
@@ -255,10 +255,9 @@ def set_log_folder(folder_path):
     return True
 
 def open_log_folder():
-    """
-    ログフォルダをOSに依存せず開く
-    """
-    folder_path = _log_folder
+    """ログフォルダをOSに依存せず開く"""
+    # ブール値が入り込むと os.path.exists で例外となるため正規化
+    folder_path = get_absolute_path(_log_folder)
     
     if not os.path.exists(folder_path):
         try:

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -86,6 +86,11 @@ def save_settings(settings):
 
 def open_output_folder(folder_path):
     """指定されたフォルダをOSに依存せず開く"""
+    # ブール値やNoneが渡されてもエラーにならないよう文字列に変換
+    if isinstance(folder_path, bool) or folder_path is None:
+        folder_path = ""
+    folder_path = os.path.abspath(os.path.realpath(str(folder_path)))
+
     if not os.path.exists(folder_path):
         os.makedirs(folder_path, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- prevent boolean values from causing path errors
- normalise folder path inputs in `open_output_folder` and `open_log_folder`

## Testing
- `python -m py_compile webui/eichi_utils/settings_manager.py webui/eichi_utils/log_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68652ed5cb88832f8a1c45e74af97ca7