### PR TITLE
Fix bool path bug with ensure_dir utility

### DIFF
--- a/README/README_changelog.md
+++ b/README/README_changelog.md
@@ -7,6 +7,8 @@
 ### 2025-07-03: バージョン1.9.x – Path safety refactor & robust logging
 - パス結合を共通関数 `safe_path_join()` 経由に統一し、不正値によるクラッシュを回避
 - `log_and_continue()` デコレータでワーカー処理の例外をログに残して継続
+### 2025-07-03  v1.9.x-3
+* add `ensure_dir()` – converts bool/None/'' to default path, prevents os.makedirs TypeError.
 
 ### 2025-05-22: バージョン1.9.4 ※正式リリース版
 - **設定保存機能の実装**:

--- a/tests/test_ensure_dir.py
+++ b/tests/test_ensure_dir.py
@@ -1,0 +1,13 @@
+import pathlib, importlib.util, pytest
+spec = importlib.util.spec_from_file_location(
+    "pu", "webui/eichi_utils/path_utils.py"
+)
+pu = importlib.util.module_from_spec(spec); spec.loader.exec_module(pu)
+
+@pytest.mark.parametrize("val", [False, True, None, "", "なし"])
+def test_default(val):
+    assert pu.ensure_dir(val, "out").name == "out"
+
+def test_custom(tmp_path):
+    p = tmp_path / "xyz"
+    assert pu.ensure_dir(str(p)) == p

--- a/version/v1.9.3/webui/eichi_utils/path_utils.py
+++ b/version/v1.9.3/webui/eichi_utils/path_utils.py
@@ -1,6 +1,17 @@
 import os
 from pathlib import Path
 
+def ensure_dir(dir_val, default_name="outputs") -> Path:
+    """Convert to ``Path`` and fall back to ``default_name`` for falsy values."""
+
+    if (
+        isinstance(dir_val, (str, os.PathLike))
+        and str(dir_val).strip()
+        and str(dir_val) != "なし"
+    ):
+        return Path(dir_val)
+    return Path(default_name)
+
 def safe_path_join(base: os.PathLike, *parts: str) -> Path:
     """Join path components while gracefully handling invalid values.
 

--- a/version/v1.9.3/webui/endframe_ichi.py
+++ b/version/v1.9.3/webui/endframe_ichi.py
@@ -109,7 +109,7 @@ from eichi_utils.lora_preset_manager import (
     load_lora_preset,
     get_preset_names
 )
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 
 # キーフレーム処理モジュールをインポート
@@ -554,6 +554,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
 
     # 処理時間計測の開始

--- a/version/v1.9.3/webui/endframe_ichi_f1.py
+++ b/version/v1.9.3/webui/endframe_ichi_f1.py
@@ -107,7 +107,7 @@ from eichi_utils.keyframe_handler_extended import extended_mode_length_change_ha
 import gradio as gr
 # UI関連モジュールのインポート
 from eichi_utils.ui_styles import get_app_css
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 import torch
 import einops
@@ -383,6 +383,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
 
     # 処理時間計測の開始

--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -139,7 +139,7 @@ from eichi_utils.lora_preset_manager import (
 
 import gradio as gr
 from eichi_utils.ui_styles import get_app_css
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 import torch
 import einops
@@ -425,7 +425,8 @@ def worker(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs,
     else:
         # 出力フォルダはwebui内のoutputsに固定
         outputs_folder = os.path.join(webui_folder, 'outputs')
-    
+
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
     
     # プログレスバーの初期化
@@ -2199,6 +2200,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
     
     # 出力ディレクトリを設定

--- a/webui/eichi_utils/path_utils.py
+++ b/webui/eichi_utils/path_utils.py
@@ -1,6 +1,17 @@
 import os
 from pathlib import Path
 
+def ensure_dir(dir_val, default_name="outputs") -> Path:
+    """Convert to ``Path`` and fall back to ``default_name`` for falsy values."""
+
+    if (
+        isinstance(dir_val, (str, os.PathLike))
+        and str(dir_val).strip()
+        and str(dir_val) != "なし"
+    ):
+        return Path(dir_val)
+    return Path(default_name)
+
 def safe_path_join(base: os.PathLike, *parts: str) -> Path:
     """Join path components while gracefully handling invalid values.
 

--- a/webui/eichi_utils/tensor_tool.py
+++ b/webui/eichi_utils/tensor_tool.py
@@ -136,7 +136,7 @@ from eichi_utils.preset_manager import (
     save_preset,
     delete_preset,
 )
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 
 # 拡張キーフレーム処理モジュールをインポート
 from eichi_utils.keyframe_handler_extended import extended_mode_length_change_handler
@@ -366,6 +366,7 @@ print(translate("設定から入力フォルダを読み込み: {0}").format(inp
 
 # 出力フォルダのフルパスを生成
 outputs_folder = get_output_folder_path(output_folder_name)
+outputs_folder = ensure_dir(outputs_folder, "outputs")
 os.makedirs(outputs_folder, exist_ok=True)
 
 # 入力フォルダも存在確認して作成
@@ -526,6 +527,7 @@ def worker(
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
 
     # 処理時間計測の開始

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -121,7 +121,7 @@ from eichi_utils.lora_preset_manager import (
     get_preset_names
 )
 from eichi_utils import lora_state_cache
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 
 # キーフレーム処理モジュールをインポート
@@ -617,6 +617,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
 
     # 処理時間計測の開始

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -131,7 +131,7 @@ import math
 from PIL import Image
 from diffusers import AutoencoderKLHunyuanVideo
 from transformers import LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 from diffusers_helper.hunyuan import encode_prompt_conds, vae_decode, vae_encode, vae_decode_fake
 from diffusers_helper.utils import save_bcthw_as_mp4, crop_or_pad_yield_mask, soft_append_bcthw, resize_and_center_crop, state_dict_weighted_merge, state_dict_offset_merge, generate_timestamp
@@ -2567,6 +2567,7 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
 
     # 処理時間計測の開始

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -145,7 +145,7 @@ from eichi_utils.lora_preset_manager import (
     get_preset_names
 )
 from eichi_utils import prompt_cache, lora_state_cache
-from eichi_utils import safe_path_join
+from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 from eichi_utils.favorite_settings_manager import load_favorites, save_favorite, delete_favorite
 
@@ -432,7 +432,8 @@ def worker(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs,
     else:
         # 出力フォルダはwebui内のoutputsに固定
         outputs_folder = os.path.join(webui_folder, 'outputs')
-    
+
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
     
     # プログレスバーの初期化
@@ -1994,6 +1995,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         print(translate("デフォルト出力フォルダを使用: {0}").format(outputs_folder))
 
     # フォルダが存在しない場合は作成
+    outputs_folder = ensure_dir(outputs_folder, "outputs")
     os.makedirs(outputs_folder, exist_ok=True)
     
     # 出力ディレクトリを設定


### PR DESCRIPTION
## Summary
- add new `ensure_dir()` helper in `path_utils` and copy to versioned tree
- sanitize output directory creation in main workers using `ensure_dir`
- add tests for `ensure_dir`
- document `ensure_dir` in changelog

## Testing
- `pytest -q`
- `grep -R "expected str, bytes or os.PathLike" -n || echo "OK"`

------
https://chatgpt.com/codex/tasks/task_e_68662410c6dc832fafe6cbcb4631a403