### PR TITLE
Fix reference image path bug

### DIFF
--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -2387,8 +2387,8 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                 
             # ワーカー実行 - 詳細設定パラメータを含む（キュー機能対応）
             async_run(worker, current_image, current_prompt, n_prompt, current_seed, steps, cfg, gs, rs,
-                     gpu_memory_preservation, use_teacache, lora_files, lora_files2, lora_scales_text,
-                     output_dir, use_lora, fp8_optimization, resolution,
+                     gpu_memory_preservation, use_teacache, use_prompt_cache, lora_files, lora_files2, lora_scales_text,
+                     output_dir, save_input_images, use_lora, fp8_optimization, resolution,
                      current_latent_window_size, latent_index, use_clean_latents_2x, use_clean_latents_4x, use_clean_latents_post,
                      lora_mode, lora_dropdown1, lora_dropdown2, lora_dropdown3, lora_files3,
                      batch_index, use_queue, prompt_queue_file,
@@ -3639,7 +3639,7 @@ with block:
     )
     
     # 生成開始・中止のイベント
-    ips = [input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache,
+    ips = [input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_preservation, use_teacache, use_prompt_cache,
            lora_files, lora_files2, lora_scales_text, use_lora, fp8_optimization, resolution, output_dir,
            batch_count, use_random_seed, latent_window_size, latent_index,
            use_clean_latents_2x, use_clean_latents_4x, use_clean_latents_post,

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2226,7 +2226,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                 
             # ワーカー実行 - 詳細設定パラメータを含む（キュー機能対応）
             async_run(worker, current_image, current_prompt, n_prompt, current_seed, steps, cfg, gs, rs,
-                     gpu_memory_preservation, use_teacache, lora_files, lora_files2, lora_scales_text,
+                     gpu_memory_preservation, use_teacache, use_prompt_cache, lora_files, lora_files2, lora_scales_text,
                      output_dir, save_input_images, use_lora, fp8_optimization, resolution,
                      current_latent_window_size, latent_index, use_clean_latents_2x, use_clean_latents_4x, use_clean_latents_post,
                      lora_mode, lora_dropdown1, lora_dropdown2, lora_dropdown3, lora_files3,


### PR DESCRIPTION
## Summary
- align parameters when calling `worker()`
- include `use_prompt_cache` in the v1.9.3 UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662cb0f2c0832f8abb9628c7c92128