### PR TITLE
Fix LoRA cache key generation for Path objects

### DIFF
--- a/tests/test_lora_cache_key.py
+++ b/tests/test_lora_cache_key.py
@@ -28,3 +28,17 @@ def test_cache_key_order_insensitive(tmp_path):
     ], [str(b), str(a)], [1.0, 0.5], False)
 
     assert key1 == key2
+
+
+def test_cache_key_accepts_path_objects(tmp_path):
+    model = tmp_path / "model.safetensors"
+    model.write_text("m")
+    lora = tmp_path / "lora.safetensors"
+    lora.write_text("l")
+
+    key = lora_state_cache.generate_cache_key([
+        model
+    ], [lora], [0.5], True)
+
+    assert isinstance(key, str)
+    assert len(key) == 64

--- a/webui/eichi_utils/lora_state_cache.py
+++ b/webui/eichi_utils/lora_state_cache.py
@@ -26,7 +26,7 @@ def generate_cache_key(model_files, lora_paths, lora_scales, fp8_enabled):
     items = []
 
     # model files are order independent
-    for path in sorted(model_files or []):
+    for path in sorted([str(p) for p in (model_files or [])]):
         if os.path.exists(path):
             items.append(path)
             items.append(str(os.path.getmtime(path)))
@@ -34,7 +34,8 @@ def generate_cache_key(model_files, lora_paths, lora_scales, fp8_enabled):
     # keep LoRA paths paired with their scale values when sorting
     if lora_paths:
         scales = lora_scales or [None] * len(lora_paths)
-        for path, scale in sorted(zip(lora_paths, scales), key=lambda x: x[0]):
+        pairs = [(str(p), s) for p, s in zip(lora_paths, scales)]
+        for path, scale in sorted(pairs, key=lambda x: x[0]):
             if os.path.exists(path):
                 items.append(path)
                 items.append(str(os.path.getmtime(path)))


### PR DESCRIPTION
## Summary
- handle `Path` objects correctly in LoRA cache key generation
- add regression test for Path-like support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667708abcc832f928cb020e95b18ec