### PR TITLE
Add timestamp to error logs

### DIFF
--- a/webui/eichi_utils/error_utils.py
+++ b/webui/eichi_utils/error_utils.py
@@ -4,7 +4,13 @@ import traceback
 logger = logging.getLogger("eichi")
 if not logger.handlers:
     logger.setLevel(logging.INFO)
-    logger.addHandler(logging.FileHandler("eichi.log", encoding="utf-8"))
+    handler = logging.FileHandler("eichi.log", encoding="utf-8")
+    formatter = logging.Formatter(
+        fmt="[%(asctime)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
 
 def log_and_continue(msg: str = "Unhandled exception"):


### PR DESCRIPTION
## Summary
- format `eichi.log` entries with `[YYYY-MM-DD HH:MM:SS]` timestamp

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868bada8e84832fa9f25726a6c563b8