### PR TITLE
Add option to save original input files

### DIFF
--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -288,6 +288,7 @@ def get_default_app_settings_oichi():
 
         # 自動保存・アラーム設定
         "save_input_images": False,
+        "save_before_input_images": False,
         "save_settings_on_start": False,
         "alarm_on_completion": True
     }


### PR DESCRIPTION
## Summary
- rename "入力画像を保存" label to "計算時入力画像を保存"
- add new checkbox and setting to save original input images before processing
- copy input/reference images and masks to output folder when enabled
- persist new option in app settings and favourites

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4877fb18832f92b4c1256926181f