### PR TITLE
Fix LoRA cache option persistence

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3159,6 +3159,8 @@ css = get_app_css()
 # アプリケーション起動時に保存された設定を読み込む
 from eichi_utils.settings_manager import load_app_settings
 saved_app_settings = load_app_settings()
+if saved_app_settings:
+    lora_state_cache.set_cache_enabled(saved_app_settings.get("lora_cache", False))
 
 block = gr.Blocks(css=css).queue()
 with block:
@@ -3576,7 +3578,7 @@ with block:
             with gr.Row():
                 lora_cache_checkbox = gr.Checkbox(
                     label=translate("LoRAの設定を再起動時再利用する"),
-                    value=False,
+                    value=saved_app_settings.get("lora_cache", False) if saved_app_settings else False,
                     info=translate("チェックをオンにすると、FP8最適化済みのLoRA重みをキャッシュして再利用します")
                 )
 

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -68,6 +68,8 @@ except ImportError:
 # 設定管理のインポートと読み込み
 from eichi_utils.settings_manager import load_app_settings_f1
 saved_app_settings = load_app_settings_f1()
+if saved_app_settings:
+    lora_state_cache.set_cache_enabled(saved_app_settings.get("lora_cache", False))
 
 # 読み込んだ設定をログに出力
 if saved_app_settings:
@@ -4769,7 +4771,7 @@ with block:
             with gr.Row():
                 lora_cache_checkbox = gr.Checkbox(
                     label=translate("LoRAの設定を再起動時再利用する"),
-                    value=False,
+                    value=saved_app_settings.get("lora_cache", False) if saved_app_settings else False,
                     info=translate("チェックをオンにすると、FP8最適化済みのLoRA重みをキャッシュして再利用します")
                 )
 


### PR DESCRIPTION
## Summary
- ensure that LoRA cache option is restored on start
- initialize checkbox values from saved settings for Endframe modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a77c007b0832f8f9a63f7247dca1e