### PR TITLE
Fix device mismatch when using prompt cache

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -967,12 +967,14 @@ def worker(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs,
             llama_vec, llama_attention_mask = crop_or_pad_yield_mask(llama_vec, length=512)
             llama_vec_n, llama_attention_mask_n = crop_or_pad_yield_mask(llama_vec_n, length=512)
         
-        # データ型変換
-        llama_vec = llama_vec.to(transformer.dtype)
-        llama_vec_n = llama_vec_n.to(transformer.dtype)
-        clip_l_pooler = clip_l_pooler.to(transformer.dtype)
-        clip_l_pooler_n = clip_l_pooler_n.to(transformer.dtype)
-        image_encoder_last_hidden_state = image_encoder_last_hidden_state.to(transformer.dtype)
+        # データ型変換とデバイス移動
+        llama_vec = llama_vec.to(device=gpu, dtype=transformer.dtype)
+        llama_vec_n = llama_vec_n.to(device=gpu, dtype=transformer.dtype)
+        clip_l_pooler = clip_l_pooler.to(device=gpu, dtype=transformer.dtype)
+        clip_l_pooler_n = clip_l_pooler_n.to(device=gpu, dtype=transformer.dtype)
+        llama_attention_mask = llama_attention_mask.to(gpu)
+        llama_attention_mask_n = llama_attention_mask_n.to(gpu)
+        image_encoder_last_hidden_state = image_encoder_last_hidden_state.to(device=gpu, dtype=transformer.dtype)
         
         # endframe_ichiと同様に、テキストエンコーダーのメモリを完全に解放
         if not high_vram:


### PR DESCRIPTION
## Summary
- ensure cached prompt tensors move to GPU before sampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a89a3e894832f91de0067d4f1373f