### PR TITLE
Improve debug messages for LoRA path

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -4078,6 +4078,10 @@ with block:
                     """./loraディレクトリからLoRAモデルファイルを検索する関数"""
                     lora_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lora')
                     choices = []
+
+                    # 現在の作業ディレクトリとLoRAディレクトリのパスを表示
+                    print(translate("現在の作業ディレクトリ: {0}").format(os.getcwd()))
+                    print(translate("LoRAディレクトリパス: {0}").format(lora_dir))
                     
                     # ディレクトリが存在しない場合は作成
                     if not os.path.exists(lora_dir):

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2977,6 +2977,10 @@ with block:
                         """./loraディレクトリからLoRAモデルファイルを検索する関数"""
                         lora_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lora')
                         choices = []
+
+                        # 現在の作業ディレクトリとLoRAディレクトリのパスを表示
+                        print(translate("現在の作業ディレクトリ: {0}").format(os.getcwd()))
+                        print(translate("LoRAディレクトリパス: {0}").format(lora_dir))
                         
                         # ディレクトリが存在しない場合は作成
                         if not os.path.exists(lora_dir):


### PR DESCRIPTION
## Summary
- show working directory and LoRA folder path when scanning for LoRA files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a912b1ce0832fa3c88b9398657717