### PR TITLE
Add cache file logs

### DIFF
--- a/webui/eichi_utils/lora_state_cache.py
+++ b/webui/eichi_utils/lora_state_cache.py
@@ -50,17 +50,23 @@ def generate_cache_key(model_files, lora_paths, lora_scales, fp8_enabled):
 def load_from_cache(cache_key):
     """Load cached state dict if available."""
     cache_file = os.path.join(get_cache_dir(), cache_key + '.pt')
+    print(f"Looking for LoRA state cache: {cache_file}")
     if os.path.exists(cache_file):
         try:
-            return torch.load(cache_file)
+            data = torch.load(cache_file)
+            print("LoRA state cache hit")
+            return data
         except Exception as e:
             print(f"Failed to load LoRA state cache: {e}")
+            return None
+    print("LoRA state cache miss")
     return None
 
 
 def save_to_cache(cache_key, state_dict):
     """Save state dict to cache."""
     cache_file = os.path.join(get_cache_dir(), cache_key + '.pt')
+    print(f"Saving LoRA state cache: {cache_file}")
     try:
         torch.save(state_dict, cache_file)
     except Exception as e:

--- a/webui/eichi_utils/prompt_cache.py
+++ b/webui/eichi_utils/prompt_cache.py
@@ -20,17 +20,23 @@ def prompt_hash(prompt: str, n_prompt: str) -> str:
 def load_from_cache(prompt: str, n_prompt: str):
     """Load cached tensors from disk if available."""
     cache_file = os.path.join(get_cache_dir(), prompt_hash(prompt, n_prompt) + '.pt')
+    print(f"Looking for prompt cache: {cache_file}")
     if os.path.exists(cache_file):
         try:
-            return torch.load(cache_file)
+            data = torch.load(cache_file)
+            print("Prompt cache hit")
+            return data
         except Exception:
+            print("Failed to load prompt cache")
             return None
+    print("Prompt cache miss")
     return None
 
 
 def save_to_cache(prompt: str, n_prompt: str, data: dict):
     """Save tensors to disk cache."""
     cache_file = os.path.join(get_cache_dir(), prompt_hash(prompt, n_prompt) + '.pt')
+    print(f"Saving prompt cache: {cache_file}")
     try:
         torch.save(data, cache_file)
     except Exception as e:


### PR DESCRIPTION
## Summary
- print file paths when saving/loading prompt caches
- print file paths when saving/loading LoRA state caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac1866a94832fb0223f96e2b68cda