### PR TITLE
Add reference image long-edge option

### DIFF
--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -286,6 +286,9 @@ def get_default_app_settings_oichi():
         # キュー設定
         "use_queue": False,
 
+        # 参照画像長辺合わせ
+        "reference_long_edge": False,
+
         # 自動保存・アラーム設定
         "save_input_images": False,
         "save_before_input_images": False,


### PR DESCRIPTION
## Summary
- implement `resize_and_pad_with_edge_color` helper
- add checkbox to use long-edge resize for reference images
- persist new setting in settings manager and UI save/reset
- apply long-edge padding when enabled for reference image and mask

## Testing
- `python -m py_compile webui/oneframe_ichi.py webui/eichi_utils/settings_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_686d9916ee84832f870dfff756539176