### PR TITLE
Fix folder open on Linux without xdg-open

### DIFF
--- a/version/v1.9.3/webui/eichi_utils/settings_manager.py
+++ b/version/v1.9.3/webui/eichi_utils/settings_manager.py
@@ -6,6 +6,8 @@ endframe_ichi.pyから外出しした設定ファイル関連処理を含む
 import os
 import json
 import subprocess
+import sys
+import shutil
 from locales.i18n_extended import translate
 
 def get_settings_file_path():
@@ -88,11 +90,16 @@ def open_output_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
-        elif os.name == 'posix':  # Linux/Mac
-            try:
-                subprocess.Popen(['xdg-open', folder_path])
-            except:
-                subprocess.Popen(['open', folder_path])
+        elif os.name == 'posix':
+            opener = None
+            if sys.platform == 'darwin' and shutil.which('open'):
+                opener = 'open'
+            else:
+                opener = shutil.which('xdg-open') or shutil.which('open')
+            if opener:
+                subprocess.Popen([opener, folder_path])
+            else:
+                raise FileNotFoundError('xdg-open/open not found')
         print(translate("フォルダを開きました: {0}").format(folder_path))
         return True
     except Exception as e:

--- a/version/v1.9.3/webui/endframe_ichi.py
+++ b/version/v1.9.3/webui/endframe_ichi.py
@@ -21,6 +21,7 @@ import os
 import random
 import time
 import subprocess
+import shutil
 import traceback  # デバッグログ出力用
 # クロスプラットフォーム対応のための条件付きインポート
 import yaml
@@ -3558,11 +3559,16 @@ with block:
                         try:
                             if os.name == 'nt':  # Windows
                                 os.startfile(input_dir)
-                            elif os.name == 'posix':  # macOS, Linux
-                                if sys.platform == 'darwin':  # macOS
-                                    subprocess.Popen(['open', input_dir])
-                                else:  # Linux
-                                    subprocess.Popen(['xdg-open', input_dir])
+                            elif os.name == 'posix':
+                                opener = None
+                                if sys.platform == 'darwin' and shutil.which('open'):
+                                    opener = 'open'
+                                else:
+                                    opener = shutil.which('xdg-open') or shutil.which('open')
+                                if opener:
+                                    subprocess.Popen([opener, input_dir])
+                                else:
+                                    raise FileNotFoundError('xdg-open/open not found')
                             print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             return translate("設定を保存し、入力フォルダを開きました")
                         except Exception as e:

--- a/version/v1.9.3/webui/endframe_ichi_f1.py
+++ b/version/v1.9.3/webui/endframe_ichi_f1.py
@@ -13,6 +13,7 @@ import os
 import random
 import time
 import subprocess
+import shutil
 import traceback  # デバッグログ出力用
 # クロスプラットフォーム対応のための条件付きインポート
 import yaml
@@ -2493,11 +2494,16 @@ with block:
                     try:
                         if os.name == 'nt':  # Windows
                             os.startfile(input_dir)
-                        elif os.name == 'posix':  # macOS, Linux
-                            if sys.platform == 'darwin':  # macOS
-                                subprocess.Popen(['open', input_dir])
-                            else:  # Linux
-                                subprocess.Popen(['xdg-open', input_dir])
+                        elif os.name == 'posix':
+                            opener = None
+                            if sys.platform == 'darwin' and shutil.which('open'):
+                                opener = 'open'
+                            else:
+                                opener = shutil.which('xdg-open') or shutil.which('open')
+                            if opener:
+                                subprocess.Popen([opener, input_dir])
+                            else:
+                                raise FileNotFoundError('xdg-open/open not found')
                         print(translate("入力フォルダを開きました: {0}").format(input_dir))
                         return translate("設定を保存し、入力フォルダを開きました")
                     except Exception as e:

--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -39,6 +39,7 @@ import argparse
 import json
 import glob
 import subprocess  # フォルダを開くために必要
+import shutil
 from PIL import Image
 
 # PNGメタデータ処理モジュールのインポート
@@ -164,11 +165,16 @@ def open_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
-        elif os.name == 'posix':  # Linux/Mac
-            try:
-                subprocess.Popen(['xdg-open', folder_path])
-            except:
-                subprocess.Popen(['open', folder_path])
+        elif os.name == 'posix':
+            opener = None
+            if sys.platform == 'darwin' and shutil.which('open'):
+                opener = 'open'
+            else:
+                opener = shutil.which('xdg-open') or shutil.which('open')
+            if opener:
+                subprocess.Popen([opener, folder_path])
+            else:
+                raise FileNotFoundError('xdg-open/open not found')
         print(translate("フォルダを開きました: {0}").format(folder_path))
         return True
     except Exception as e:

--- a/webui/eichi_utils/log_manager.py
+++ b/webui/eichi_utils/log_manager.py
@@ -6,6 +6,8 @@
 import os
 import sys
 import datetime
+import subprocess
+import shutil
 from locales.i18n_extended import translate
 
 # グローバル変数
@@ -268,14 +270,17 @@ def open_log_folder():
     
     try:
         if os.name == 'nt':  # Windows
-            import subprocess
             subprocess.Popen(['explorer', folder_path])
-        elif os.name == 'posix':  # Linux/Mac
-            import subprocess
-            try:
-                subprocess.Popen(['xdg-open', folder_path])
-            except:
-                subprocess.Popen(['open', folder_path])
+        elif os.name == 'posix':
+            opener = None
+            if sys.platform == 'darwin' and shutil.which('open'):
+                opener = 'open'
+            else:
+                opener = shutil.which('xdg-open') or shutil.which('open')
+            if opener:
+                subprocess.Popen([opener, folder_path])
+            else:
+                raise FileNotFoundError('xdg-open/open not found')
         print(translate("ログフォルダを開きました: {0}").format(folder_path))
         return True
     except Exception as e:

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -6,6 +6,8 @@ endframe_ichi.pyから外出しした設定ファイル関連処理を含む
 import os
 import json
 import subprocess
+import sys
+import shutil
 from locales.i18n_extended import translate
 
 def get_settings_file_path():
@@ -116,11 +118,16 @@ def open_output_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
-        elif os.name == 'posix':  # Linux/Mac
-            try:
-                subprocess.Popen(['xdg-open', folder_path])
-            except:
-                subprocess.Popen(['open', folder_path])
+        elif os.name == 'posix':
+            opener = None
+            if sys.platform == 'darwin' and shutil.which('open'):
+                opener = 'open'
+            else:
+                opener = shutil.which('xdg-open') or shutil.which('open')
+            if opener:
+                subprocess.Popen([opener, folder_path])
+            else:
+                raise FileNotFoundError('xdg-open/open not found')
         print(translate("フォルダを開きました: {0}").format(folder_path))
         return True
     except Exception as e:

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -27,6 +27,7 @@ import os
 import random
 import time
 import subprocess
+import shutil
 import traceback  # ログ出力用
 # クロスプラットフォーム対応のための条件付きインポート
 import yaml
@@ -3505,11 +3506,16 @@ with block:
                         try:
                             if os.name == 'nt':  # Windows
                                 os.startfile(input_dir)
-                            elif os.name == 'posix':  # macOS, Linux
-                                if sys.platform == 'darwin':  # macOS
-                                    subprocess.Popen(['open', input_dir])
-                                else:  # Linux
-                                    subprocess.Popen(['xdg-open', input_dir])
+                            elif os.name == 'posix':
+                                opener = None
+                                if sys.platform == 'darwin' and shutil.which('open'):
+                                    opener = 'open'
+                                else:
+                                    opener = shutil.which('xdg-open') or shutil.which('open')
+                                if opener:
+                                    subprocess.Popen([opener, input_dir])
+                                else:
+                                    raise FileNotFoundError('xdg-open/open not found')
                             print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             return translate("設定を保存し、入力フォルダを開きました")
                         except Exception as e:

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -14,6 +14,7 @@ import os
 import random
 import time
 import subprocess
+import shutil
 import traceback  # ログ出力用
 # クロスプラットフォーム対応のための条件付きインポート
 import yaml
@@ -4650,11 +4651,16 @@ with block:
                     try:
                         if os.name == 'nt':  # Windows
                             os.startfile(input_dir)
-                        elif os.name == 'posix':  # macOS, Linux
-                            if sys.platform == 'darwin':  # macOS
-                                subprocess.Popen(['open', input_dir])
-                            else:  # Linux
-                                subprocess.Popen(['xdg-open', input_dir])
+                        elif os.name == 'posix':
+                            opener = None
+                            if sys.platform == 'darwin' and shutil.which('open'):
+                                opener = 'open'
+                            else:
+                                opener = shutil.which('xdg-open') or shutil.which('open')
+                            if opener:
+                                subprocess.Popen([opener, input_dir])
+                            else:
+                                raise FileNotFoundError('xdg-open/open not found')
                         print(translate("入力フォルダを開きました: {0}").format(input_dir))
                         return translate("設定を保存し、入力フォルダを開きました")
                     except Exception as e:

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -182,11 +182,16 @@ def open_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
-        elif os.name == 'posix':  # Linux/Mac
-            try:
-                subprocess.Popen(['xdg-open', folder_path])
-            except:
-                subprocess.Popen(['open', folder_path])
+        elif os.name == 'posix':
+            opener = None
+            if sys.platform == 'darwin' and shutil.which('open'):
+                opener = 'open'
+            else:
+                opener = shutil.which('xdg-open') or shutil.which('open')
+            if opener:
+                subprocess.Popen([opener, folder_path])
+            else:
+                raise FileNotFoundError('xdg-open/open not found')
         print(translate("フォルダを開きました: {0}").format(folder_path))
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- handle missing `xdg-open` by falling back to other openers
- update folder-opening logic across modules
- keep old version scripts in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a8ce20a0832fac49d8ec1df7dc44