### PR TITLE
Add progress prints for module imports

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -160,17 +160,46 @@ from eichi_utils.ui_styles import get_app_css
 print(translate("PyTorchを読み込んでいます..."))
 import torch
 print(translate("完了."))
-import einops
-import safetensors.torch as sf
-import numpy as np
-import math
 
+print(translate("einopsを読み込んでいます..."))
+import einops
+print(translate("完了."))
+
+print(translate("safetensorsを読み込んでいます..."))
+import safetensors.torch as sf
+print(translate("完了."))
+
+print(translate("NumPyを読み込んでいます..."))
+import numpy as np
+print(translate("完了."))
+
+print(translate("mathを読み込んでいます..."))
+import math
+print(translate("完了."))
+
+print(translate("PILを読み込んでいます..."))
 from PIL import Image
+print(translate("完了."))
+
+print(translate("diffusersを読み込んでいます..."))
 from diffusers import AutoencoderKLHunyuanVideo
+print(translate("完了."))
+
+print(translate("transformersを読み込んでいます..."))
 from transformers import LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer
+print(translate("完了."))
+
+print(translate("diffusers_helper.hunyuanを読み込んでいます..."))
 from diffusers_helper.hunyuan import encode_prompt_conds, vae_decode, vae_encode, vae_decode_fake
+print(translate("完了."))
+
+print(translate("diffusers_helper.utilsを読み込んでいます..."))
 from diffusers_helper.utils import save_bcthw_as_mp4, crop_or_pad_yield_mask, soft_append_bcthw, resize_and_center_crop, state_dict_weighted_merge, state_dict_offset_merge, generate_timestamp
+print(translate("完了."))
+
+print(translate("diffusers_helper.modelsを読み込んでいます..."))
 from diffusers_helper.models.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
+print(translate("完了."))
 
 # フォルダを開く関数
 def open_folder(folder_path):
@@ -197,17 +226,45 @@ def open_folder(folder_path):
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))
         return False
+print(translate("diffusers_helper.pipelinesを読み込んでいます..."))
 from diffusers_helper.pipelines.k_diffusion_hunyuan import sample_hunyuan
-from diffusers_helper.memory import cpu, gpu, gpu_complete_modules, get_cuda_free_memory_gb, move_model_to_device_with_memory_preservation, offload_model_from_device_for_memory_preservation, fake_diffusers_current_device, DynamicSwapInstaller, unload_complete_models, load_model_as_complete
-from diffusers_helper.thread_utils import AsyncStream, async_run
-from diffusers_helper.gradio.progress_bar import make_progress_bar_css, make_progress_bar_html
-from eichi_utils.ui_styles import get_app_css
-from transformers import SiglipImageProcessor, SiglipVisionModel
-from diffusers_helper.clip_vision import hf_clip_vision_encode
-from diffusers_helper.bucket_tools import find_nearest_bucket, SAFE_RESOLUTIONS
+print(translate("完了."))
 
+print(translate("diffusers_helper.memoryを読み込んでいます..."))
+from diffusers_helper.memory import cpu, gpu, gpu_complete_modules, get_cuda_free_memory_gb, move_model_to_device_with_memory_preservation, offload_model_from_device_for_memory_preservation, fake_diffusers_current_device, DynamicSwapInstaller, unload_complete_models, load_model_as_complete
+print(translate("完了."))
+
+print(translate("diffusers_helper.thread_utilsを読み込んでいます..."))
+from diffusers_helper.thread_utils import AsyncStream, async_run
+print(translate("完了."))
+
+print(translate("diffusers_helper.gradioを読み込んでいます..."))
+from diffusers_helper.gradio.progress_bar import make_progress_bar_css, make_progress_bar_html
+print(translate("完了."))
+
+print(translate("eichi_utils.ui_stylesを読み込んでいます..."))
+from eichi_utils.ui_styles import get_app_css
+print(translate("完了."))
+
+print(translate("transformers(Siglip)を読み込んでいます..."))
+from transformers import SiglipImageProcessor, SiglipVisionModel
+print(translate("完了."))
+
+print(translate("diffusers_helper.clip_visionを読み込んでいます..."))
+from diffusers_helper.clip_vision import hf_clip_vision_encode
+print(translate("完了."))
+
+print(translate("diffusers_helper.bucket_toolsを読み込んでいます..."))
+from diffusers_helper.bucket_tools import find_nearest_bucket, SAFE_RESOLUTIONS
+print(translate("完了."))
+
+print(translate("eichi_utils.transformer_managerを読み込んでいます..."))
 from eichi_utils.transformer_manager import TransformerManager
+print(translate("完了."))
+
+print(translate("eichi_utils.text_encoder_managerを読み込んでいます..."))
 from eichi_utils.text_encoder_manager import TextEncoderManager
+print(translate("完了."))
 
 free_mem_gb = get_cuda_free_memory_gb(gpu)
 high_vram = free_mem_gb > 100
@@ -216,7 +273,9 @@ print(translate('Free VRAM {0} GB').format(free_mem_gb))
 print(translate('High-VRAM Mode: {0}').format(high_vram))
 
 # モデルを並列ダウンロードしておく
+print(translate("eichi_utils.model_downloaderを読み込んでいます..."))
 from eichi_utils.model_downloader import ModelDownloader
+print(translate("完了."))
 ModelDownloader().download_original()
 
 def _norm_dropdown(val):


### PR DESCRIPTION
## Summary
- provide clearer progress output during startup
- add print messages before and after loading heavy modules in `oneframe_ichi.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3400e668832f91e5019b56c74c8c