### PR TITLE
Handle missing xdg-open gracefully

### DIFF
--- a/version/v1.9.3/webui/eichi_utils/settings_manager.py
+++ b/version/v1.9.3/webui/eichi_utils/settings_manager.py
@@ -90,6 +90,7 @@ def open_output_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
+            print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None
             if sys.platform == 'darwin' and shutil.which('open'):
@@ -98,9 +99,11 @@ def open_output_folder(folder_path):
                 opener = shutil.which('xdg-open') or shutil.which('open')
             if opener:
                 subprocess.Popen([opener, folder_path])
+                print(translate("フォルダを開きました: {0}").format(folder_path))
             else:
-                raise FileNotFoundError('xdg-open/open not found')
-        print(translate("フォルダを開きました: {0}").format(folder_path))
+                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+        else:
+            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
         return True
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))

--- a/version/v1.9.3/webui/endframe_ichi.py
+++ b/version/v1.9.3/webui/endframe_ichi.py
@@ -3559,6 +3559,7 @@ with block:
                         try:
                             if os.name == 'nt':  # Windows
                                 os.startfile(input_dir)
+                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             elif os.name == 'posix':
                                 opener = None
                                 if sys.platform == 'darwin' and shutil.which('open'):
@@ -3567,10 +3568,12 @@ with block:
                                     opener = shutil.which('xdg-open') or shutil.which('open')
                                 if opener:
                                     subprocess.Popen([opener, input_dir])
+                                    print(translate("入力フォルダを開きました: {0}").format(input_dir))
                                 else:
-                                    raise FileNotFoundError('xdg-open/open not found')
-                            print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                            return translate("設定を保存し、入力フォルダを開きました")
+                                    print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
+                            else:
+                                print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
+                            return translate("設定を保存しました")
                         except Exception as e:
                             error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                             print(error_msg)

--- a/version/v1.9.3/webui/endframe_ichi_f1.py
+++ b/version/v1.9.3/webui/endframe_ichi_f1.py
@@ -2502,10 +2502,12 @@ with block:
                                 opener = shutil.which('xdg-open') or shutil.which('open')
                             if opener:
                                 subprocess.Popen([opener, input_dir])
+                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             else:
-                                raise FileNotFoundError('xdg-open/open not found')
-                        print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                        return translate("設定を保存し、入力フォルダを開きました")
+                                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
+                        else:
+                            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
+                        return translate("設定を保存しました")
                     except Exception as e:
                         error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                         print(error_msg)

--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -165,6 +165,7 @@ def open_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
+            print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None
             if sys.platform == 'darwin' and shutil.which('open'):
@@ -173,9 +174,11 @@ def open_folder(folder_path):
                 opener = shutil.which('xdg-open') or shutil.which('open')
             if opener:
                 subprocess.Popen([opener, folder_path])
+                print(translate("フォルダを開きました: {0}").format(folder_path))
             else:
-                raise FileNotFoundError('xdg-open/open not found')
-        print(translate("フォルダを開きました: {0}").format(folder_path))
+                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+        else:
+            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
         return True
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))

--- a/webui/eichi_utils/log_manager.py
+++ b/webui/eichi_utils/log_manager.py
@@ -271,6 +271,7 @@ def open_log_folder():
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
+            print(translate("ログフォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None
             if sys.platform == 'darwin' and shutil.which('open'):
@@ -279,9 +280,11 @@ def open_log_folder():
                 opener = shutil.which('xdg-open') or shutil.which('open')
             if opener:
                 subprocess.Popen([opener, folder_path])
+                print(translate("ログフォルダを開きました: {0}").format(folder_path))
             else:
-                raise FileNotFoundError('xdg-open/open not found')
-        print(translate("ログフォルダを開きました: {0}").format(folder_path))
+                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+        else:
+            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
         return True
     except Exception as e:
         print(translate("ログフォルダを開く際にエラーが発生しました: {0}").format(e))

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -118,6 +118,7 @@ def open_output_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
+            print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None
             if sys.platform == 'darwin' and shutil.which('open'):
@@ -126,9 +127,11 @@ def open_output_folder(folder_path):
                 opener = shutil.which('xdg-open') or shutil.which('open')
             if opener:
                 subprocess.Popen([opener, folder_path])
+                print(translate("フォルダを開きました: {0}").format(folder_path))
             else:
-                raise FileNotFoundError('xdg-open/open not found')
-        print(translate("フォルダを開きました: {0}").format(folder_path))
+                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+        else:
+            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
         return True
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3506,6 +3506,7 @@ with block:
                         try:
                             if os.name == 'nt':  # Windows
                                 os.startfile(input_dir)
+                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             elif os.name == 'posix':
                                 opener = None
                                 if sys.platform == 'darwin' and shutil.which('open'):
@@ -3514,10 +3515,12 @@ with block:
                                     opener = shutil.which('xdg-open') or shutil.which('open')
                                 if opener:
                                     subprocess.Popen([opener, input_dir])
+                                    print(translate("入力フォルダを開きました: {0}").format(input_dir))
                                 else:
-                                    raise FileNotFoundError('xdg-open/open not found')
-                            print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                            return translate("設定を保存し、入力フォルダを開きました")
+                                    print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
+                            else:
+                                print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
+                            return translate("設定を保存しました")
                         except Exception as e:
                             error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                             print(error_msg)

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4651,6 +4651,7 @@ with block:
                     try:
                         if os.name == 'nt':  # Windows
                             os.startfile(input_dir)
+                            print(translate("入力フォルダを開きました: {0}").format(input_dir))
                         elif os.name == 'posix':
                             opener = None
                             if sys.platform == 'darwin' and shutil.which('open'):
@@ -4659,10 +4660,12 @@ with block:
                                 opener = shutil.which('xdg-open') or shutil.which('open')
                             if opener:
                                 subprocess.Popen([opener, input_dir])
+                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
                             else:
-                                raise FileNotFoundError('xdg-open/open not found')
-                        print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                        return translate("設定を保存し、入力フォルダを開きました")
+                                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
+                        else:
+                            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
+                        return translate("設定を保存しました")
                     except Exception as e:
                         error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                         print(error_msg)

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -190,6 +190,7 @@ def open_folder(folder_path):
     try:
         if os.name == 'nt':  # Windows
             subprocess.Popen(['explorer', folder_path])
+            print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None
             if sys.platform == 'darwin' and shutil.which('open'):
@@ -198,9 +199,11 @@ def open_folder(folder_path):
                 opener = shutil.which('xdg-open') or shutil.which('open')
             if opener:
                 subprocess.Popen([opener, folder_path])
+                print(translate("フォルダを開きました: {0}").format(folder_path))
             else:
-                raise FileNotFoundError('xdg-open/open not found')
-        print(translate("フォルダを開きました: {0}").format(folder_path))
+                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+        else:
+            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
         return True
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))


### PR DESCRIPTION
## Summary
- prevent crashes when the system lacks `xdg-open`/`open`
- log a message if no opener exists
- update the older versioned scripts as well

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a345b1540832f8ab4fc9c61b64eb6