### PR TITLE
Fix resync button output mismatch

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3211,7 +3211,9 @@ def end_after_step_process():
 def resync_status_handler():
     """Re-synchronize progress display after page reload."""
     global last_progress_desc, last_progress_bar
-    return translate("✅ Status resynchronized"), last_progress_desc, last_progress_bar
+    # Log message for clarity; UI does not display it directly
+    print(translate("✅ Status resynchronized"))
+    return last_progress_desc, last_progress_bar
 
 def end_after_step_process():
     """現在のステップ完了後に停止する処理"""


### PR DESCRIPTION
## Summary
- fix `resync_status_handler` output mismatch by returning only the progress data
- log a message to the console for user awareness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1e436d78832f8f60e586949ef323