### PR TITLE
Fix stop-after actions interrupt sequence

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3187,23 +3187,27 @@ def end_process():
 
 def end_after_current_process():
     """現在の生成完了後に停止する処理"""
-    global batch_stopped, stop_after_current
+    global batch_stopped, stop_after_current, stream
 
     if not stop_after_current:
         batch_stopped = True
         stop_after_current = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。開始前または現在の処理完了後に停止します..."))
 
     return gr.update(value=translate("打ち切り処理中..."), interactive=False)
 
 def end_after_step_process():
     """現在のステップ完了後に停止する処理"""
-    global batch_stopped, stop_after_current, stop_after_step
+    global batch_stopped, stop_after_current, stop_after_step, stream
 
     if not stop_after_step:
         batch_stopped = True
         stop_after_current = True
         stop_after_step = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。現在のステップ完了後に停止します..."))
 
     return gr.update(value=translate("停止処理中..."), interactive=False)
@@ -3217,12 +3221,14 @@ def resync_status_handler():
 
 def end_after_step_process():
     """現在のステップ完了後に停止する処理"""
-    global batch_stopped, stop_after_current, stop_after_step
+    global batch_stopped, stop_after_current, stop_after_step, stream
 
     if not stop_after_step:
         batch_stopped = True
         stop_after_current = True
         stop_after_step = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。現在のステップ完了後に停止します..."))
 
     return gr.update(value=translate("停止処理中..."), interactive=False)

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -1092,11 +1092,13 @@ def end_process_enhanced():
 
 def end_after_current_process_enhanced():
     """Stop after the current generation completes"""
-    global batch_stopped, stop_after_current
+    global batch_stopped, stop_after_current, stream
 
     if not stop_after_current:
         batch_stopped = True
         stop_after_current = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。開始前または現在の処理完了後に停止します..."))
 
     return (

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2743,7 +2743,7 @@ def end_process():
 
 def end_after_current_process():
     """現在の生成完了後に停止する処理"""
-    global batch_stopped, stop_after_current
+    global batch_stopped, stop_after_current, stream
 
     if stop_after_current:
         # キャンセル処理
@@ -2757,6 +2757,8 @@ def end_after_current_process():
     else:
         batch_stopped = True
         stop_after_current = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。開始前または現在の処理完了後に停止します..."))
         return (
             gr.update(value=translate("打ち切り処理中..."), interactive=True),
@@ -2765,7 +2767,7 @@ def end_after_current_process():
 
 def end_after_step_process():
     """現在のステップ完了後に停止する処理"""
-    global batch_stopped, stop_after_current, stop_after_step
+    global batch_stopped, stop_after_current, stop_after_step, stream
 
     if stop_after_step:
         # キャンセル処理
@@ -2781,6 +2783,8 @@ def end_after_step_process():
         batch_stopped = True
         stop_after_current = True
         stop_after_step = True
+        if stream is not None and stream.input_queue.top() != 'end':
+            stream.input_queue.push('end')
         print(translate("\n停止ボタンが押されました。現在のステップ完了後に停止します..."))
         return (
             gr.update(value=translate("停止処理中..."), interactive=True),


### PR DESCRIPTION
## Summary
- ensure that stop-after buttons push `end` to the worker queue
- propagate queue stop in oneframe and endframe scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8ebd2374832fb07ab7adbfb83c2d