### PR TITLE
Fix stop buttons reset

### DIFF
--- a/version/v1.9.3/webui/endframe_ichi.py
+++ b/version/v1.9.3/webui/endframe_ichi.py
@@ -2845,7 +2845,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
             '',
             gr.update(interactive=True),
             gr.update(interactive=False, value=translate("End Generation")),
-            gr.update()
+            gr.update(interactive=False, value=translate("この生成で打ち切り"))
         )
         return
 
@@ -2861,7 +2861,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 '',
                 gr.update(interactive=True),
                 gr.update(interactive=False, value=translate("End Generation")),
-                gr.update()
+                gr.update(interactive=False, value=translate("この生成で打ち切り"))
             )
             break
 
@@ -2954,7 +2954,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 '',
                 gr.update(interactive=True),
                 gr.update(interactive=False, value=translate("End Generation")),
-                gr.update(interactive=False),
+                gr.update(interactive=False, value=translate("この生成で打ち切り")),
                 gr.update()
             )
             break
@@ -3188,7 +3188,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                         '',
                         gr.update(interactive=True),
                         gr.update(interactive=False, value=translate("End Generation")),
-                        gr.update(interactive=False),
+                        gr.update(interactive=False, value=translate("この生成で打ち切り")),
                         gr.update()
                     )
                 else:

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2606,8 +2606,8 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                                 '',
                                 gr.update(interactive=True, value=translate("Start Generation")),
                                 gr.update(interactive=False, value=translate("End Generation")),
-                                gr.update(interactive=False),
-                                gr.update(interactive=False),
+                                gr.update(interactive=False, value=translate("この生成で打ち切り")),
+                                gr.update(interactive=False, value=translate("このステップで打ち切り")),
                                 gr.update(value=original_seed),
                             )
                         break
@@ -2626,8 +2626,8 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                             '',
                             gr.update(interactive=True),
                             gr.update(interactive=False, value=translate("End Generation")),
-                            gr.update(interactive=False),
-                            gr.update(interactive=False),
+                            gr.update(interactive=False, value=translate("この生成で打ち切り")),
+                            gr.update(interactive=False, value=translate("このステップで打ち切り")),
                             gr.update(value=original_seed),
                         )
                         return
@@ -2671,12 +2671,12 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                 pass
             
             # UIをリセット
-            yield None, gr.update(visible=False), translate("キーボード割り込みにより処理が中断されました"), '', gr.update(interactive=True, value=translate("Start Generation")), gr.update(interactive=False, value=translate("End Generation")), gr.update(interactive=False), gr.update(interactive=False), gr.update()
+            yield None, gr.update(visible=False), translate("キーボード割り込みにより処理が中断されました"), '', gr.update(interactive=True, value=translate("Start Generation")), gr.update(interactive=False, value=translate("End Generation")), gr.update(interactive=False, value=translate("この生成で打ち切り")), gr.update(interactive=False, value=translate("このステップで打ち切り")), gr.update()
             return
         except Exception as e:
             import traceback
             # UIをリセット
-            yield None, gr.update(visible=False), translate("エラーにより処理が中断されました"), '', gr.update(interactive=True, value=translate("Start Generation")), gr.update(interactive=False, value=translate("End Generation")), gr.update(interactive=False), gr.update(interactive=False), gr.update()
+            yield None, gr.update(visible=False), translate("エラーにより処理が中断されました"), '', gr.update(interactive=True, value=translate("Start Generation")), gr.update(interactive=False, value=translate("End Generation")), gr.update(interactive=False, value=translate("この生成で打ち切り")), gr.update(interactive=False, value=translate("このステップで打ち切り")), gr.update()
             return
     
     # すべてのバッチ処理が正常に完了した場合と中断された場合で表示メッセージを分ける


### PR DESCRIPTION
## Summary
- reset stop-after buttons when generation finishes or aborts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8eecd838832fa3885abf74fa500d