### PR TITLE
Fix global variable usage in process

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2604,7 +2604,6 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                             completion_message = f"{completion_message} - {progress_summary}"
 
                             # 完了メッセージでUIを更新
-                            global last_output_filename
                             last_output_filename = output_filename
                             yield (
                                 output_filename if output_filename is not None else gr.skip(),


### PR DESCRIPTION
## Summary
- remove extra `global last_output_filename` declaration in `oneframe_ichi.py`

## Testing
- `pytest -q`
- `python -m py_compile webui/oneframe_ichi.py && echo "compile success"`

------
https://chatgpt.com/codex/tasks/task_e_6881106a028c832fbe528ce67fabdf19