### PR TITLE
Fix resync NameError

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -37,6 +37,7 @@ last_progress_desc = ""
 last_progress_bar = ""
 last_preview_image = None
 last_output_filename = None
+current_seed = None
 
 # 進捗表示用グローバル変数
 progress_ref_idx = 0


### PR DESCRIPTION
## Summary
- initialize `current_seed` at startup to allow resync before any generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811f589154832f8ec9b9d065aa9995