### PR TITLE
Fix stop flags not global

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2541,6 +2541,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     global prompt_queue_file_path
     global vae_cache_enabled
     global image_queue_files
+    global stop_after_current, stop_after_step
 
     # バッチ処理開始時に停止フラグをリセット
     batch_stopped = False


### PR DESCRIPTION
## Summary
- ensure `stop_after_current` and `stop_after_step` are updated globally in endframe mode
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884805e9bd0832fb8e04c241e5a780b