### PR TITLE
Add spinner helper and use for module imports

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -1,0 +1,29 @@
+import itertools
+import sys
+import threading
+import time
+from locales.i18n_extended import translate
+
+def spinner_while_running(message, function, *args, **kwargs):
+    """Display a spinner with ``message`` while ``function`` executes."""
+    braille_chars = ["⠇", "⠋", "⠙", "⠸", "⢰", "⣠", "⣄", "⡆"]
+    spinner_cycle = itertools.cycle(braille_chars)
+    done = threading.Event()
+
+    def spinner():
+        while not done.is_set():
+            sys.stdout.write(f"{{{next(spinner_cycle)}}} {message}")
+            sys.stdout.flush()
+            time.sleep(0.1)
+            sys.stdout.write('\r')
+
+    spinner_thread = threading.Thread(target=spinner)
+    spinner_thread.start()
+    try:
+        result = function(*args, **kwargs)
+    finally:
+        done.set()
+        spinner_thread.join()
+        sys.stdout.write(translate("完了."))
+        sys.stdout.write('\n')
+    return result

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -168,64 +168,97 @@ from eichi_utils import prompt_cache, lora_state_cache
 from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 from eichi_utils.favorite_settings_manager import load_favorites, save_favorite, delete_favorite
+from eichi_utils.spinner import spinner_while_running
+import importlib
 
 import gradio as gr
 from eichi_utils.ui_styles import get_app_css
 
-print(translate("PyTorchを読み込んでいます..."), end="", flush=True)
-import torch
-print(translate("完了."), end="", flush=True)
-print()
+torch = spinner_while_running(
+    translate("PyTorchを読み込んでいます..."),
+    importlib.import_module,
+    "torch",
+)
 
-print(translate("einopsを読み込んでいます..."), end="", flush=True)
-import einops
-print(translate("完了."), end="", flush=True)
-print()
+einops = spinner_while_running(
+    translate("einopsを読み込んでいます..."),
+    importlib.import_module,
+    "einops",
+)
 
-print(translate("safetensorsを読み込んでいます..."), end="", flush=True)
-import safetensors.torch as sf
-print(translate("完了."), end="", flush=True)
-print()
+sf = spinner_while_running(
+    translate("safetensorsを読み込んでいます..."),
+    importlib.import_module,
+    "safetensors.torch",
+)
 
-print(translate("NumPyを読み込んでいます..."), end="", flush=True)
-import numpy as np
-print(translate("完了."), end="", flush=True)
-print()
+np = spinner_while_running(
+    translate("NumPyを読み込んでいます..."),
+    importlib.import_module,
+    "numpy",
+)
 
-print(translate("mathを読み込んでいます..."), end="", flush=True)
-import math
-print(translate("完了."), end="", flush=True)
-print()
+math = spinner_while_running(
+    translate("mathを読み込んでいます..."),
+    importlib.import_module,
+    "math",
+)
 
-print(translate("PILを読み込んでいます..."), end="", flush=True)
-from PIL import Image
-print(translate("完了."), end="", flush=True)
-print()
+Image = spinner_while_running(
+    translate("PILを読み込んでいます..."),
+    lambda: importlib.import_module("PIL").Image,
+)
 
-print(translate("diffusersを読み込んでいます..."), end="", flush=True)
-from diffusers import AutoencoderKLHunyuanVideo
-print(translate("完了."), end="", flush=True)
-print()
+AutoencoderKLHunyuanVideo = spinner_while_running(
+    translate("diffusersを読み込んでいます..."),
+    lambda: importlib.import_module("diffusers").AutoencoderKLHunyuanVideo,
+)
 
-print(translate("transformersを読み込んでいます..."), end="", flush=True)
-from transformers import LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer
-print(translate("完了."), end="", flush=True)
-print()
+LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer = spinner_while_running(
+    translate("transformersを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("transformers").LlamaModel,
+        importlib.import_module("transformers").CLIPTextModel,
+        importlib.import_module("transformers").LlamaTokenizerFast,
+        importlib.import_module("transformers").CLIPTokenizer,
+    ),
+)
 
-print(translate("diffusers_helper.hunyuanを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.hunyuan import encode_prompt_conds, vae_decode, vae_encode, vae_decode_fake
-print(translate("完了."), end="", flush=True)
-print()
+encode_prompt_conds, vae_decode, vae_encode, vae_decode_fake = spinner_while_running(
+    translate("diffusers_helper.hunyuanを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.hunyuan").encode_prompt_conds,
+        importlib.import_module("diffusers_helper.hunyuan").vae_decode,
+        importlib.import_module("diffusers_helper.hunyuan").vae_encode,
+        importlib.import_module("diffusers_helper.hunyuan").vae_decode_fake,
+    ),
+)
 
-print(translate("diffusers_helper.utilsを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.utils import save_bcthw_as_mp4, crop_or_pad_yield_mask, soft_append_bcthw, resize_and_center_crop, state_dict_weighted_merge, state_dict_offset_merge, generate_timestamp
-print(translate("完了."), end="", flush=True)
-print()
+(
+    save_bcthw_as_mp4,
+    crop_or_pad_yield_mask,
+    soft_append_bcthw,
+    resize_and_center_crop,
+    state_dict_weighted_merge,
+    state_dict_offset_merge,
+    generate_timestamp,
+) = spinner_while_running(
+    translate("diffusers_helper.utilsを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.utils").save_bcthw_as_mp4,
+        importlib.import_module("diffusers_helper.utils").crop_or_pad_yield_mask,
+        importlib.import_module("diffusers_helper.utils").soft_append_bcthw,
+        importlib.import_module("diffusers_helper.utils").resize_and_center_crop,
+        importlib.import_module("diffusers_helper.utils").state_dict_weighted_merge,
+        importlib.import_module("diffusers_helper.utils").state_dict_offset_merge,
+        importlib.import_module("diffusers_helper.utils").generate_timestamp,
+    ),
+)
 
-print(translate("diffusers_helper.modelsを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.models.hunyuan_video_packed import HunyuanVideoTransformer3DModelPacked
-print(translate("完了."), end="", flush=True)
-print()
+HunyuanVideoTransformer3DModelPacked = spinner_while_running(
+    translate("diffusers_helper.modelsを読み込んでいます..."),
+    lambda: importlib.import_module("diffusers_helper.models.hunyuan_video_packed").HunyuanVideoTransformer3DModelPacked,
+)
 
 
 # フォルダを開く関数
@@ -257,55 +290,87 @@ def open_folder(folder_path):
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))
         return False
 
-print(translate("diffusers_helper.pipelinesを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.pipelines.k_diffusion_hunyuan import sample_hunyuan
-print(translate("完了."), end="", flush=True)
-print()
+sample_hunyuan = spinner_while_running(
+    translate("diffusers_helper.pipelinesを読み込んでいます..."),
+    lambda: importlib.import_module("diffusers_helper.pipelines.k_diffusion_hunyuan").sample_hunyuan,
+)
 
-print(translate("diffusers_helper.memoryを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.memory import cpu, gpu, gpu_complete_modules, get_cuda_free_memory_gb, move_model_to_device_with_memory_preservation, offload_model_from_device_for_memory_preservation, fake_diffusers_current_device, DynamicSwapInstaller, unload_complete_models, load_model_as_complete
-print(translate("完了."), end="", flush=True)
-print()
+(
+    cpu,
+    gpu,
+    gpu_complete_modules,
+    get_cuda_free_memory_gb,
+    move_model_to_device_with_memory_preservation,
+    offload_model_from_device_for_memory_preservation,
+    fake_diffusers_current_device,
+    DynamicSwapInstaller,
+    unload_complete_models,
+    load_model_as_complete,
+) = spinner_while_running(
+    translate("diffusers_helper.memoryを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.memory").cpu,
+        importlib.import_module("diffusers_helper.memory").gpu,
+        importlib.import_module("diffusers_helper.memory").gpu_complete_modules,
+        importlib.import_module("diffusers_helper.memory").get_cuda_free_memory_gb,
+        importlib.import_module("diffusers_helper.memory").move_model_to_device_with_memory_preservation,
+        importlib.import_module("diffusers_helper.memory").offload_model_from_device_for_memory_preservation,
+        importlib.import_module("diffusers_helper.memory").fake_diffusers_current_device,
+        importlib.import_module("diffusers_helper.memory").DynamicSwapInstaller,
+        importlib.import_module("diffusers_helper.memory").unload_complete_models,
+        importlib.import_module("diffusers_helper.memory").load_model_as_complete,
+    ),
+)
 
-print(translate("diffusers_helper.thread_utilsを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.thread_utils import AsyncStream, async_run
-print(translate("完了."), end="", flush=True)
-print()
+AsyncStream, async_run = spinner_while_running(
+    translate("diffusers_helper.thread_utilsを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.thread_utils").AsyncStream,
+        importlib.import_module("diffusers_helper.thread_utils").async_run,
+    ),
+)
 
-print(translate("diffusers_helper.gradioを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.gradio.progress_bar import make_progress_bar_css, make_progress_bar_html
-print(translate("完了."), end="", flush=True)
-print()
+make_progress_bar_css, make_progress_bar_html = spinner_while_running(
+    translate("diffusers_helper.gradioを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.gradio.progress_bar").make_progress_bar_css,
+        importlib.import_module("diffusers_helper.gradio.progress_bar").make_progress_bar_html,
+    ),
+)
 
-print(translate("eichi_utils.ui_stylesを読み込んでいます..."), end="", flush=True)
-from eichi_utils.ui_styles import get_app_css
-print(translate("完了."), end="", flush=True)
-print()
+# get_app_css was imported earlier from eichi_utils.ui_styles
 
-print(translate("transformers(Siglip)を読み込んでいます..."), end="", flush=True)
-from transformers import SiglipImageProcessor, SiglipVisionModel
-print(translate("完了."), end="", flush=True)
-print()
 
-print(translate("diffusers_helper.clip_visionを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.clip_vision import hf_clip_vision_encode
-print(translate("完了."), end="", flush=True)
-print()
+SiglipImageProcessor, SiglipVisionModel = spinner_while_running(
+    translate("transformers(Siglip)を読み込んでいます..."),
+    lambda: (
+        importlib.import_module("transformers").SiglipImageProcessor,
+        importlib.import_module("transformers").SiglipVisionModel,
+    ),
+)
 
-print(translate("diffusers_helper.bucket_toolsを読み込んでいます..."), end="", flush=True)
-from diffusers_helper.bucket_tools import find_nearest_bucket, SAFE_RESOLUTIONS
-print(translate("完了."), end="", flush=True)
-print()
+hf_clip_vision_encode = spinner_while_running(
+    translate("diffusers_helper.clip_visionを読み込んでいます..."),
+    lambda: importlib.import_module("diffusers_helper.clip_vision").hf_clip_vision_encode,
+)
 
-print(translate("eichi_utils.transformer_managerを読み込んでいます..."), end="", flush=True)
-from eichi_utils.transformer_manager import TransformerManager
-print(translate("完了."), end="", flush=True)
-print()
+find_nearest_bucket, SAFE_RESOLUTIONS = spinner_while_running(
+    translate("diffusers_helper.bucket_toolsを読み込んでいます..."),
+    lambda: (
+        importlib.import_module("diffusers_helper.bucket_tools").find_nearest_bucket,
+        importlib.import_module("diffusers_helper.bucket_tools").SAFE_RESOLUTIONS,
+    ),
+)
 
-print(translate("eichi_utils.text_encoder_managerを読み込んでいます..."), end="", flush=True)
-from eichi_utils.text_encoder_manager import TextEncoderManager
-print(translate("完了."), end="", flush=True)
-print()
+TransformerManager = spinner_while_running(
+    translate("eichi_utils.transformer_managerを読み込んでいます..."),
+    lambda: importlib.import_module("eichi_utils.transformer_manager").TransformerManager,
+)
+
+TextEncoderManager = spinner_while_running(
+    translate("eichi_utils.text_encoder_managerを読み込んでいます..."),
+    lambda: importlib.import_module("eichi_utils.text_encoder_manager").TextEncoderManager,
+)
 
 
 free_mem_gb = get_cuda_free_memory_gb(gpu)
@@ -315,10 +380,10 @@ print(translate('Free VRAM {0} GB').format(free_mem_gb))
 print(translate('High-VRAM Mode: {0}').format(high_vram))
 
 # モデルを並列ダウンロードしておく
-print(translate("eichi_utils.model_downloaderを読み込んでいます..."), end="", flush=True)
-from eichi_utils.model_downloader import ModelDownloader
-print(translate("完了."), end="", flush=True)
-print()
+ModelDownloader = spinner_while_running(
+    translate("eichi_utils.model_downloaderを読み込んでいます..."),
+    lambda: importlib.import_module("eichi_utils.model_downloader").ModelDownloader,
+)
 
 ModelDownloader().download_original()
 


### PR DESCRIPTION
## Summary
- add a new helper `spinner_while_running` in `webui/eichi_utils/spinner.py`
- use the spinner when importing modules in `oneframe_ichi.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68848a7901a0832fb30ebeca9ae30219