### PR TITLE
Improve spinner output handling

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -12,10 +12,10 @@ def spinner_while_running(message, function, *args, **kwargs):
 
     def spinner():
         while not done.is_set():
+            sys.stdout.write('\r\x1b[2K')  # clear current line
             sys.stdout.write(f"{next(spinner_cycle)} {message}")
             sys.stdout.flush()
             time.sleep(0.1)
-            sys.stdout.write('\r')
 
     spinner_thread = threading.Thread(target=spinner)
     spinner_thread.start()
@@ -24,6 +24,7 @@ def spinner_while_running(message, function, *args, **kwargs):
     finally:
         done.set()
         spinner_thread.join()
+        sys.stdout.write('\r\x1b[2K')  # clear spinner line
         sys.stdout.write("✅")
         sys.stdout.write('\n')
     return result


### PR DESCRIPTION
## Summary
- avoid spinner text corruption by clearing current line before writing
- clear spinner line before displaying completion mark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688492f07a94832fb112eee2063f6c33