### PR TITLE
Improve spinner output handling

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -3,27 +3,69 @@ import sys
 import threading
 import time
 from locales.i18n_extended import translate
+import queue
+import contextlib
+import io
 
 def spinner_while_running(message, function, *args, **kwargs):
     """Display a spinner with ``message`` while ``function`` executes."""
     braille_chars = ["⠇", "⠋", "⠙", "⠸", "⢰", "⣠", "⣄", "⡆"]
     spinner_cycle = itertools.cycle(braille_chars)
+
     done = threading.Event()
+    print_lock = threading.Lock()
+    out_queue = queue.Queue()
+
+    class QueueWriter(io.StringIO):
+        def write(self, s):
+            if s:
+                out_queue.put(s)
+        def flush(self):
+            pass
+
+    def printer():
+        while True:
+            chunk = out_queue.get()
+            if chunk is None:
+                break
+            with print_lock:
+                sys.stdout.write(chunk)
+                sys.stdout.flush()
 
     def spinner():
-        while not done.is_set():
-            sys.stdout.write(f"{next(spinner_cycle)} {message}")
+        with print_lock:
+            sys.stdout.write(f"{next(spinner_cycle)} {message}\n")
             sys.stdout.flush()
+        while not done.is_set():
+            with print_lock:
+                sys.stdout.write('\x1b[1A\r\x1b[2K')
+                sys.stdout.write(f"{next(spinner_cycle)} {message}\n")
+                sys.stdout.flush()
             time.sleep(0.1)
-            sys.stdout.write('\r')
+
+    result_container = {}
+
+    def run_func():
+        with contextlib.redirect_stdout(QueueWriter()):
+            result_container['result'] = function(*args, **kwargs)
+        out_queue.put(None)
 
     spinner_thread = threading.Thread(target=spinner)
+    printer_thread = threading.Thread(target=printer)
+    runner_thread = threading.Thread(target=run_func)
+
     spinner_thread.start()
-    try:
-        result = function(*args, **kwargs)
-    finally:
-        done.set()
-        spinner_thread.join()
-        sys.stdout.write("✅")
-        sys.stdout.write('\n')
-    return result
+    printer_thread.start()
+    runner_thread.start()
+
+    runner_thread.join()
+    done.set()
+    spinner_thread.join()
+    printer_thread.join()
+
+    with print_lock:
+        sys.stdout.write('\x1b[1A\r\x1b[2K')
+        sys.stdout.write(f"✅ {message}\n")
+        sys.stdout.flush()
+
+    return result_container.get('result')


### PR DESCRIPTION
## Summary
- handle stdout while spinner runs so output appears on subsequent lines
- keep message when showing completion check mark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688492f07a94832fb112eee2063f6c33