### PR TITLE
Fix spinner freeze

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -3,9 +3,7 @@ import sys
 import threading
 import time
 from locales.i18n_extended import translate
-import queue
-import contextlib
-import io
+
 
 def spinner_while_running(message, function, *args, **kwargs):
     """Display a spinner with ``message`` while ``function`` executes."""
@@ -13,59 +11,41 @@ def spinner_while_running(message, function, *args, **kwargs):
     spinner_cycle = itertools.cycle(braille_chars)
 
     done = threading.Event()
-    print_lock = threading.Lock()
-    out_queue = queue.Queue()
+    lock = threading.Lock()
+    original_stdout = sys.stdout
 
-    class QueueWriter(io.StringIO):
+    class LockedStdout:
         def write(self, s):
-            if s:
-                out_queue.put(s)
-        def flush(self):
-            pass
+            with lock:
+                original_stdout.write(s)
+                original_stdout.flush()
 
-    def printer():
-        while True:
-            chunk = out_queue.get()
-            if chunk is None:
-                break
-            with print_lock:
-                sys.stdout.write(chunk)
-                sys.stdout.flush()
+        def flush(self):
+            with lock:
+                original_stdout.flush()
 
     def spinner():
-        with print_lock:
-            sys.stdout.write(f"{next(spinner_cycle)} {message}\n")
-            sys.stdout.flush()
+        with lock:
+            original_stdout.write(f"{next(spinner_cycle)} {message}\n")
+            original_stdout.flush()
         while not done.is_set():
-            with print_lock:
-                sys.stdout.write('\x1b[1A\r\x1b[2K')
-                sys.stdout.write(f"{next(spinner_cycle)} {message}\n")
-                sys.stdout.flush()
             time.sleep(0.1)
-
-    result_container = {}
-
-    def run_func():
-        with contextlib.redirect_stdout(QueueWriter()):
-            result_container['result'] = function(*args, **kwargs)
-        out_queue.put(None)
+            with lock:
+                original_stdout.write("\x1b[1A\r\x1b[2K")
+                original_stdout.write(f"{next(spinner_cycle)} {message}\n")
+                original_stdout.flush()
+        with lock:
+            original_stdout.write("\x1b[1A\r\x1b[2K")
+            original_stdout.write(f"✅ {message}\n")
+            original_stdout.flush()
 
     spinner_thread = threading.Thread(target=spinner)
-    printer_thread = threading.Thread(target=printer)
-    runner_thread = threading.Thread(target=run_func)
-
+    sys.stdout = LockedStdout()
     spinner_thread.start()
-    printer_thread.start()
-    runner_thread.start()
-
-    runner_thread.join()
-    done.set()
-    spinner_thread.join()
-    printer_thread.join()
-
-    with print_lock:
-        sys.stdout.write('\x1b[1A\r\x1b[2K')
-        sys.stdout.write(f"✅ {message}\n")
-        sys.stdout.flush()
-
-    return result_container.get('result')
+    try:
+        result = function(*args, **kwargs)
+    finally:
+        done.set()
+        spinner_thread.join()
+        sys.stdout = original_stdout
+    return result


### PR DESCRIPTION
## Summary
- restore spinner line rewrite approach while keeping simple interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688496fdbf28832f953e0ce77adb9704