### PR TITLE
Add original size modal view for images

### DIFF
--- a/webui/eichi_utils/ui_styles.py
+++ b/webui/eichi_utils/ui_styles.py
@@ -207,4 +207,38 @@ def get_app_css():
     .group-border {
         border: solid 1px;
     }
+
+    /* ===== 原寸大表示モーダル ===== */
+    #orig_size_modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        background: rgba(0, 0, 0, 0.8);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+    }
+
+    #orig_size_modal.visible {
+        display: flex;
+    }
+
+    #orig_size_modal img {
+        max-width: 90%;
+        max-height: 90%;
+    }
+
+    #orig_size_close {
+        position: absolute;
+        top: 20px;
+        right: 30px;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 2rem;
+        cursor: pointer;
+    }
     """

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3321,6 +3321,39 @@ block = gr.Blocks(css=css).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-eichi</span></h1>')
 
+    # 原寸大表示用モーダルとボタン追加スクリプト
+    gr.HTML("""
+    <div id='orig_size_modal'>
+      <button id='orig_size_close'>×</button>
+      <img id='orig_size_img'>
+    </div>
+    <script>
+    function setupOrigSize(){
+      const modal=document.getElementById('orig_size_modal');
+      const imgElem=document.getElementById('orig_size_img');
+      const closeBtn=document.getElementById('orig_size_close');
+      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
+      function addButtons(){
+        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
+          if(div.querySelector('.orig-size-btn')) return;
+          const img=div.querySelector('img');
+          const toolbar=div.querySelector('div.flex');
+          if(!img||!toolbar) return;
+          const btn=document.createElement('button');
+          btn.innerText='原寸';
+          btn.className='orig-size-btn';
+          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
+          toolbar.insertBefore(btn, toolbar.firstChild);
+        });
+      }
+      addButtons();
+      const obs=new MutationObserver(addButtons);
+      obs.observe(document.body,{childList:true,subtree:true});
+    }
+    window.addEventListener('load', setupOrigSize);
+    </script>
+    """)
+
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置
     with gr.Row():
         with gr.Column(scale=1):

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4499,6 +4499,39 @@ block = gr.Blocks(css=css).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-<s>eichi</s> F1</span></h1>')
 
+    # 原寸大表示用モーダルとボタン追加スクリプト
+    gr.HTML("""
+    <div id='orig_size_modal'>
+      <button id='orig_size_close'>×</button>
+      <img id='orig_size_img'>
+    </div>
+    <script>
+    function setupOrigSize(){
+      const modal=document.getElementById('orig_size_modal');
+      const imgElem=document.getElementById('orig_size_img');
+      const closeBtn=document.getElementById('orig_size_close');
+      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
+      function addButtons(){
+        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
+          if(div.querySelector('.orig-size-btn')) return;
+          const img=div.querySelector('img');
+          const toolbar=div.querySelector('div.flex');
+          if(!img||!toolbar) return;
+          const btn=document.createElement('button');
+          btn.innerText='原寸';
+          btn.className='orig-size-btn';
+          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
+          toolbar.insertBefore(btn, toolbar.firstChild);
+        });
+      }
+      addButtons();
+      const obs=new MutationObserver(addButtons);
+      obs.observe(document.body,{childList:true,subtree:true});
+    }
+    window.addEventListener('load', setupOrigSize);
+    </script>
+    """)
+
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置
     with gr.Row():
         with gr.Column(scale=1):

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2971,6 +2971,39 @@ block = gr.Blocks(css=css).queue()
 with block:
     # eichiと同じ半透明度スタイルを使用
     gr.HTML('<h1>FramePack<span class="title-suffix">-oichi</span></h1>')
+
+    # 原寸大表示用モーダルとボタン追加スクリプト
+    gr.HTML("""
+    <div id='orig_size_modal'>
+      <button id='orig_size_close'>×</button>
+      <img id='orig_size_img'>
+    </div>
+    <script>
+    function setupOrigSize(){
+      const modal=document.getElementById('orig_size_modal');
+      const imgElem=document.getElementById('orig_size_img');
+      const closeBtn=document.getElementById('orig_size_close');
+      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
+      function addButtons(){
+        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
+          if(div.querySelector('.orig-size-btn')) return;
+          const img=div.querySelector('img');
+          const toolbar=div.querySelector('div.flex');
+          if(!img||!toolbar) return;
+          const btn=document.createElement('button');
+          btn.innerText='原寸';
+          btn.className='orig-size-btn';
+          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
+          toolbar.insertBefore(btn, toolbar.firstChild);
+        });
+      }
+      addButtons();
+      const obs=new MutationObserver(addButtons);
+      obs.observe(document.body,{childList:true,subtree:true});
+    }
+    window.addEventListener('load', setupOrigSize);
+    </script>
+    """)
     
     # 初期化時にtransformerの状態確認は行わない（必要時に遅延ロード）
     # ここではロードをスキップして、ワーカー関数内で必要になったときにだけロードする


### PR DESCRIPTION
## Summary
- add CSS rules for image modal
- inject JS+HTML snippet to show an original size button for all images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a6c9306c832f869119c3847709b1