### PR TITLE
Fix spinner stdout interface compatibility

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -15,14 +15,27 @@ def spinner_while_running(message, function, *args, **kwargs):
     original_stdout = sys.stdout
 
     class LockedStdout:
+        def __init__(self, original):
+            self._original = original
+
         def write(self, s):
             with lock:
-                original_stdout.write(s)
-                original_stdout.flush()
+                self._original.write(s)
+                self._original.flush()
 
         def flush(self):
             with lock:
-                original_stdout.flush()
+                self._original.flush()
+
+        def fileno(self):
+            return self._original.fileno()
+
+        def isatty(self):
+            return self._original.isatty()
+
+        @property
+        def encoding(self):
+            return getattr(self._original, "encoding", "utf-8")
 
     def spinner():
         with lock:
@@ -40,7 +53,7 @@ def spinner_while_running(message, function, *args, **kwargs):
             original_stdout.flush()
 
     spinner_thread = threading.Thread(target=spinner)
-    sys.stdout = LockedStdout()
+    sys.stdout = LockedStdout(original_stdout)
     spinner_thread.start()
     try:
         result = function(*args, **kwargs)


### PR DESCRIPTION
## Summary
- ensure spinner's temporary stdout wrapper supports `fileno`, `isatty`, and `encoding` attributes
- keep original stdout reference when installing the wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e4960874832fa543ab47cd2a37a7