### PR TITLE
Use spinner for heavy imports

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -1,11 +1,44 @@
-import os
+
+
+from eichi_utils.spinner import spinner_while_running
+import importlib
+
+(
+    os,
+    sys,
+    asyncio,
+    login,
+    random,
+    time,
+    traceback,
+    yaml,
+    argparse,
+    json,
+    glob,
+    subprocess,
+) = spinner_while_running(
+    "Load: System Libraries",
+    lambda: (
+        importlib.import_module("os"),
+        importlib.import_module("sys"),
+        importlib.import_module("asyncio"),
+        importlib.import_module("diffusers_helper.hf_login").login,
+        importlib.import_module("random"),
+        importlib.import_module("time"),
+        importlib.import_module("traceback"),
+        importlib.import_module("yaml"),
+        importlib.import_module("argparse"),
+        importlib.import_module("json"),
+        importlib.import_module("glob"),
+        importlib.import_module("subprocess"),
+    ),
+)
 import shutil
-import sys
+
 sys.path.append(os.path.abspath(os.path.realpath(os.path.join(os.path.dirname(__file__), './submodules/FramePack'))))
 print(f"{os.path.basename(__file__)} : 起動開始....")
 
 # Windows環境で loop再生時に [WinError 10054] の warning が出るのを回避する設定
-import asyncio
 if sys.platform in ('win32', 'cygwin'):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
@@ -47,22 +80,10 @@ progress_img_idx = 0
 progress_img_total = 0
 progress_img_name = ""
 
-from diffusers_helper.hf_login import login
 
-import os
-import random  # ランダムシード生成用
-import time
 from datetime import datetime, timedelta
-import traceback  # ログ出力用
-import yaml
-import argparse
-import json
-import glob
-import subprocess  # フォルダを開くために必要
-from PIL import Image
 
 # PNGメタデータ処理モジュールのインポート
-import sys
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from eichi_utils.png_metadata import (
     embed_metadata_to_png, extract_metadata_from_png,
@@ -105,7 +126,11 @@ if is_port_in_use(args.port):
     time.sleep(10) # 10秒待機して続行
 
 try:
-    import winsound
+    winsound = spinner_while_running(
+        "Load: winsound",
+        importlib.import_module,
+        "winsound",
+    )
     HAS_WINSOUND = True
 except ImportError:
     HAS_WINSOUND = False
@@ -120,8 +145,18 @@ else:
 has_lora_support = False
 has_fp8_support = False
 try:
-    import lora_utils
-    from lora_utils.fp8_optimization_utils import check_fp8_support, apply_fp8_monkey_patch
+    lora_utils = spinner_while_running(
+        "Load: lora_utils",
+        importlib.import_module,
+        "lora_utils",
+    )
+    check_fp8_support, apply_fp8_monkey_patch = spinner_while_running(
+        "Load: lora_utils.fp8_optimization_utils",
+        lambda: (
+            importlib.import_module("lora_utils.fp8_optimization_utils").check_fp8_support,
+            importlib.import_module("lora_utils.fp8_optimization_utils").apply_fp8_monkey_patch,
+        ),
+    )
     
     has_lora_support = True
     # FP8サポート確認
@@ -138,7 +173,7 @@ except ImportError:
     print(translate("LoRAサポートが無効です（lora_utilsモジュールがインストールされていません）"))
 
 # 設定管理モジュールをインポート
-from eichi_utils.settings_manager import (
+(
     get_settings_file_path,
     get_output_folder_path,
     initialize_settings,
@@ -146,33 +181,79 @@ from eichi_utils.settings_manager import (
     save_settings,
     open_output_folder,
     load_app_settings_oichi,
-    save_app_settings_oichi
+    save_app_settings_oichi,
+) = spinner_while_running(
+    "Load: eichi_utils.settings_manager",
+    lambda: (
+        importlib.import_module("eichi_utils.settings_manager").get_settings_file_path,
+        importlib.import_module("eichi_utils.settings_manager").get_output_folder_path,
+        importlib.import_module("eichi_utils.settings_manager").initialize_settings,
+        importlib.import_module("eichi_utils.settings_manager").load_settings,
+        importlib.import_module("eichi_utils.settings_manager").save_settings,
+        importlib.import_module("eichi_utils.settings_manager").open_output_folder,
+        importlib.import_module("eichi_utils.settings_manager").load_app_settings_oichi,
+        importlib.import_module("eichi_utils.settings_manager").save_app_settings_oichi,
+    ),
 )
 
 # ログ管理モジュールをインポート
-from eichi_utils.log_manager import (
-    enable_logging, disable_logging, is_logging_enabled, 
-    get_log_folder, set_log_folder, open_log_folder,
-    get_default_log_settings, load_log_settings, apply_log_settings
+(
+    enable_logging,
+    disable_logging,
+    is_logging_enabled,
+    get_log_folder,
+    set_log_folder,
+    open_log_folder,
+    get_default_log_settings,
+    load_log_settings,
+    apply_log_settings,
+) = spinner_while_running(
+    "Load: eichi_utils.log_manager",
+    lambda: (
+        importlib.import_module("eichi_utils.log_manager").enable_logging,
+        importlib.import_module("eichi_utils.log_manager").disable_logging,
+        importlib.import_module("eichi_utils.log_manager").is_logging_enabled,
+        importlib.import_module("eichi_utils.log_manager").get_log_folder,
+        importlib.import_module("eichi_utils.log_manager").set_log_folder,
+        importlib.import_module("eichi_utils.log_manager").open_log_folder,
+        importlib.import_module("eichi_utils.log_manager").get_default_log_settings,
+        importlib.import_module("eichi_utils.log_manager").load_log_settings,
+        importlib.import_module("eichi_utils.log_manager").apply_log_settings,
+    ),
 )
 
 # LoRAプリセット管理モジュールをインポート
-from eichi_utils.lora_preset_manager import (
+(
     initialize_lora_presets,
     load_lora_presets,
     save_lora_preset,
     load_lora_preset,
-    get_preset_names
+    get_preset_names,
+) = spinner_while_running(
+    "Load: eichi_utils.lora_preset_manager",
+    lambda: (
+        importlib.import_module("eichi_utils.lora_preset_manager").initialize_lora_presets,
+        importlib.import_module("eichi_utils.lora_preset_manager").load_lora_presets,
+        importlib.import_module("eichi_utils.lora_preset_manager").save_lora_preset,
+        importlib.import_module("eichi_utils.lora_preset_manager").load_lora_preset,
+        importlib.import_module("eichi_utils.lora_preset_manager").get_preset_names,
+    ),
 )
 from eichi_utils import prompt_cache, lora_state_cache
 from eichi_utils.path_utils import safe_path_join, ensure_dir
 from eichi_utils.error_utils import log_and_continue
 from eichi_utils.favorite_settings_manager import load_favorites, save_favorite, delete_favorite
-from eichi_utils.spinner import spinner_while_running
-import importlib
 
-import gradio as gr
-from eichi_utils.ui_styles import get_app_css
+
+gr = spinner_while_running(
+    "Load: gradio",
+    importlib.import_module,
+    "gradio",
+)
+get_app_css = spinner_while_running(
+    "Load: eichi_utils.ui_styles",
+    lambda: importlib.import_module("eichi_utils.ui_styles").get_app_css,
+)
 
 torch = spinner_while_running(
     translate("Load_torch"),


### PR DESCRIPTION
## Summary
- load `spinner_while_running` and `importlib` first
- group system libraries under a single spinner
- load winsound, lora utilities and several eichi_utils modules with spinners
- show loading spinners for gradio and ui styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f4ddb470832fbfb39e06ca5d8372