### PR TITLE
Print startup message sooner

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -1,13 +1,14 @@
 
 
 from eichi_utils.spinner import spinner_while_running
-import importlib
 import os
+print(f"{os.path.basename(__file__)} : 起動開始....")
+
+import importlib
 import sys
 import argparse
 
 sys.path.append(os.path.abspath(os.path.realpath(os.path.join(os.path.dirname(__file__), './submodules/FramePack'))))
-print(f"{os.path.basename(__file__)} : 起動開始....")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--share', action='store_true')


### PR DESCRIPTION
## Summary
- move startup print to the very top of `oneframe_ichi.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856b70d1d8832fa0953b61ed04a010