### PR TITLE
Fix original size modal initialization

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3350,7 +3350,11 @@ with block:
       const obs=new MutationObserver(addButtons);
       obs.observe(document.body,{childList:true,subtree:true});
     }
-    window.addEventListener('load', setupOrigSize);
+    if(document.readyState !== 'loading'){
+      setupOrigSize();
+    } else {
+      window.addEventListener('load', setupOrigSize);
+    }
     </script>
     """)
 

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4528,7 +4528,11 @@ with block:
       const obs=new MutationObserver(addButtons);
       obs.observe(document.body,{childList:true,subtree:true});
     }
-    window.addEventListener('load', setupOrigSize);
+    if(document.readyState !== 'loading'){
+      setupOrigSize();
+    } else {
+      window.addEventListener('load', setupOrigSize);
+    }
     </script>
     """)
 

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3084,7 +3084,11 @@ with block:
       const obs=new MutationObserver(addButtons);
       obs.observe(document.body,{childList:true,subtree:true});
     }
-    window.addEventListener('load', setupOrigSize);
+    if(document.readyState !== 'loading'){
+      setupOrigSize();
+    } else {
+      window.addEventListener('load', setupOrigSize);
+    }
     </script>
     """)
     


### PR DESCRIPTION
## Summary
- ensure original size preview buttons initialize even when injected after page load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688572e68da8832fb80d3175f0f84edc