### PR TITLE
Apply spinner to path setup

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -8,7 +8,15 @@ import importlib
 import sys
 import argparse
 
-sys.path.append(os.path.abspath(os.path.realpath(os.path.join(os.path.dirname(__file__), './submodules/FramePack'))))
+spinner_while_running(
+    "Path: FramePack",
+    sys.path.append,
+    os.path.abspath(
+        os.path.realpath(
+            os.path.join(os.path.dirname(__file__), "./submodules/FramePack")
+        )
+    ),
+)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--share', action='store_true')
@@ -2270,6 +2278,8 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
     global stream
     global batch_stopped, stop_after_current, stop_after_step, user_abort, user_abort_notified
     global queue_enabled, queue_type, prompt_queue_file_path, image_queue_files, reference_queue_files
+    global progress_ref_idx, progress_ref_total, progress_ref_name
+    global progress_img_idx, progress_img_total, progress_img_name
 
     # 新たな処理開始時にグローバルフラグをリセット
     user_abort = False
@@ -2680,8 +2690,6 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                         print(translate("イメージキュー実行中: バッチ {0}/{1} は画像数を超えているため入力画像を使用").format(batch_index+1, batch_count))
 
         # 進捗用グローバル変数を更新
-        global progress_ref_idx, progress_ref_total, progress_ref_name
-        global progress_img_idx, progress_img_total, progress_img_name
         progress_ref_idx = reference_idx + 1
         progress_ref_total = ref_count
         progress_ref_name = os.path.basename(reference_image_current) if isinstance(reference_image_current, str) else translate("入力画像")


### PR DESCRIPTION
## Summary
- add spinner when appending FramePack path in `oneframe_ichi.py`
- apply the same spinner logic to `oneframe_ichi_orig.py`
- declare progress variables early to avoid syntax errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a9e08bbc832faaecc5d844937129