### PR TITLE
Use tqdm.write for safer spinner logging

### DIFF
--- a/webui/eichi_utils/tqdm_print.py
+++ b/webui/eichi_utils/tqdm_print.py
@@ -1,0 +1,21 @@
+import builtins
+import sys
+from tqdm import tqdm
+
+_original_print = builtins.print
+
+def tqdm_print(*args, **kwargs):
+    """Thread-safe print function that uses tqdm.write to avoid breaking progress displays."""
+    file = kwargs.get("file", None)
+    if file not in (None, sys.stdout):
+        _original_print(*args, **kwargs)
+        return
+    sep = kwargs.get("sep", " ")
+    end = kwargs.get("end", "\n")
+    msg = sep.join(str(a) for a in args)
+    tqdm.write(msg, end=end)
+
+
+def enable_tqdm_print():
+    """Replace the built-in print with a tqdm-based version."""
+    builtins.print = tqdm_print

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -1,6 +1,10 @@
 
 import os
 
+# Enable thread-safe printing that cooperates with progress bars/spinners
+from eichi_utils.tqdm_print import enable_tqdm_print
+enable_tqdm_print()
+
 # 即座に起動しているファイルをまずは表示
 print(f"\n------------------------------------------------------------")
 print(f"{os.path.basename(__file__)} : Starting....")


### PR DESCRIPTION
## Summary
- add helper to route print statements through `tqdm.write`
- enable `tqdm`-based printing in `oneframe_ichi`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689346954fa4832faf54183acea57b82