### PR TITLE
Fix resync button blocking generation

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -6652,7 +6652,8 @@ with block:
     resync_status_btn.click(
         fn=resync_status_handler,
         inputs=[],
-        outputs=[result_video, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, seed]
+        outputs=[result_video, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, seed],
+        queue=False
     )
 
     # キーフレーム画像変更時のイベント登録

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -1396,7 +1396,8 @@ def setup_enhanced_config_queue_events(components, ui_components):
             components['queue_status_display'],
             ui_components['progress_desc'],
             ui_components['progress_bar']
-        ]
+        ],
+        queue=False
     )
 
 def setup_periodic_queue_status_check():

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -5032,7 +5032,8 @@ with block:
     resync_status_btn.click(
         fn=resync_status_handler,
         inputs=[],
-        outputs=[result_image, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, stop_step_button, seed]
+        outputs=[result_image, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, stop_step_button, seed],
+        queue=False
     )
     
     gr.HTML(f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")}</div>')


### PR DESCRIPTION
## Summary
- Run resync actions without using the queue to avoid blocking
- Apply queue-free resync to both single and multi-frame UIs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935f344434832f8ac28944002ea850