### PR TITLE
fix: maintain completion status after resync

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -2552,6 +2552,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     global image_queue_files
     global stop_after_current, stop_after_step
     global generation_active
+    global last_progress_desc, last_progress_bar, last_preview_image, last_output_filename
 
     # バッチ処理開始時に停止フラグをリセット
     batch_stopped = False
@@ -3168,6 +3169,9 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                     else:
                         completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(batch_count, batch_count)
                     last_output_filename = batch_output_filename
+                    last_progress_desc = completion_message
+                    last_progress_bar = ''
+                    last_preview_image = None
                     yield (
                         batch_output_filename if batch_output_filename is not None else gr.skip(),
                         gr.update(value=None, visible=False),

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2358,6 +2358,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
     global progress_img_idx, progress_img_total, progress_img_name
     global last_output_filename
     global generation_active
+    global last_progress_desc, last_progress_bar, last_preview_image
 
 
     # 新たな処理開始時にグローバルフラグをリセット
@@ -2881,8 +2882,11 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                                 completion_message = translate("バッチ処理が完了しました（{0}/{1}）").format(total_batches, total_batches)
                             completion_message = f"{completion_message} - {progress_summary}"
 
-                            # 完了メッセージでUIを更新
+                            # 完了メッセージでUIを更新し、再同期用に保存
                             last_output_filename = output_filename
+                            last_progress_desc = completion_message
+                            last_progress_bar = ''
+                            last_preview_image = None
                             yield (
                                 output_filename if output_filename is not None else gr.skip(),
                                 gr.update(visible=False),


### PR DESCRIPTION
## Summary
- ensure final progress message persists across page resyncs
- store last completion message for endframe generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689499f8c328832f8cccb9b0ee9eef75