### PR TITLE
feat: broadcast progress updates for resync

### DIFF
--- a/webui/diffusers_helper/thread_utils.py
+++ b/webui/diffusers_helper/thread_utils.py
@@ -1,0 +1,102 @@
+import time
+from threading import Thread, Lock
+
+
+class Listener:
+    task_queue = []
+    lock = Lock()
+    thread = None
+
+    @classmethod
+    def _process_tasks(cls):
+        while True:
+            task = None
+            with cls.lock:
+                if cls.task_queue:
+                    task = cls.task_queue.pop(0)
+
+            if task is None:
+                time.sleep(0.001)
+                continue
+
+            func, args, kwargs = task
+            try:
+                func(*args, **kwargs)
+            except Exception as e:
+                print(f"Error in listener thread: {e}")
+
+    @classmethod
+    def add_task(cls, func, *args, **kwargs):
+        with cls.lock:
+            cls.task_queue.append((func, args, kwargs))
+
+        if cls.thread is None:
+            cls.thread = Thread(target=cls._process_tasks, daemon=True)
+            cls.thread.start()
+
+
+def async_run(func, *args, **kwargs):
+    Listener.add_task(func, *args, **kwargs)
+
+
+class FIFOQueue:
+    def __init__(self):
+        self.queue = []
+        self.lock = Lock()
+
+    def push(self, item):
+        with self.lock:
+            self.queue.append(item)
+
+    def pop(self):
+        with self.lock:
+            if self.queue:
+                return self.queue.pop(0)
+            return None
+
+    def top(self):
+        with self.lock:
+            if self.queue:
+                return self.queue[0]
+            return None
+
+    def next(self):
+        while True:
+            with self.lock:
+                if self.queue:
+                    return self.queue.pop(0)
+            time.sleep(0.001)
+
+    def clear(self):
+        with self.lock:
+            self.queue.clear()
+
+
+class BroadcastQueue:
+    """A simple broadcast queue that duplicates items to all subscribers."""
+
+    def __init__(self):
+        self.subscribers = []
+        self.lock = Lock()
+
+    def subscribe(self):
+        q = FIFOQueue()
+        with self.lock:
+            self.subscribers.append(q)
+        return q
+
+    def push(self, item):
+        with self.lock:
+            for q in self.subscribers:
+                q.push(item)
+
+    def clear(self):
+        with self.lock:
+            for q in self.subscribers:
+                q.clear()
+
+
+class AsyncStream:
+    def __init__(self):
+        self.input_queue = FIFOQueue()
+        self.output_queue = BroadcastQueue()

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3103,8 +3103,9 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         batch_output_filename = None
 
         # 現在のバッチの処理結果を取得
+        listener_queue = stream.output_queue.subscribe()
         while True:
-            flag, data = stream.output_queue.next()
+            flag, data = listener_queue.next()
 
             if flag == 'file':
                 batch_output_filename = data
@@ -3267,9 +3268,10 @@ def resync_status_handler():
     if not running or stream is None or not hasattr(stream, "output_queue"):
         return
 
+    listener_queue = stream.output_queue.subscribe()
     while True:
         try:
-            flag, data = stream.output_queue.next()
+            flag, data = listener_queue.next()
         except Exception:
             generation_active = False
             break

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4401,8 +4401,9 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         batch_output_filename = None
 
         # 現在のバッチの処理結果を取得
+        listener_queue = stream.output_queue.subscribe()
         while True:
-            flag, data = stream.output_queue.next()
+            flag, data = listener_queue.next()
 
             if flag == 'file':
                 batch_output_filename = data

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2847,9 +2847,10 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         # ジョブ完了まで監視
         try:
             # ストリーム待機開始
+            listener_queue = stream.output_queue.subscribe()
             while True:
                 try:
-                    flag, data = stream.output_queue.next()
+                    flag, data = listener_queue.next()
                     
                     if flag == 'file':
                         output_filename = data
@@ -3108,9 +3109,10 @@ def resync_status_handler():
     if not running or stream is None or not hasattr(stream, "output_queue"):
         return
 
+    listener_queue = stream.output_queue.subscribe()
     while True:
         try:
-            flag, data = stream.output_queue.next()
+            flag, data = listener_queue.next()
         except Exception:
             generation_active = False
             break


### PR DESCRIPTION
## Summary
- add `BroadcastQueue` so progress updates are delivered to all subscribers
- subscribe to the broadcast queue in generation and resync handlers
- enable multi-browser resynchronization of ongoing jobs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894a2d083c0832fa242ccf5c6da9415