### PR TITLE
Handle resync only when stream disconnected

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -283,6 +283,7 @@ def get_image_queue_files():
     return image_files
 
 stream = AsyncStream()
+stream_listener_active = False
 
 # 設定管理モジュールをインポート
 from eichi_utils.settings_manager import (
@@ -2553,6 +2554,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
     global stop_after_current, stop_after_step
     global generation_active
     global last_progress_desc, last_progress_bar, last_preview_image, last_output_filename
+    global stream_listener_active
 
     # バッチ処理開始時に停止フラグをリセット
     batch_stopped = False
@@ -2817,6 +2819,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         yield gr.skip(), None, '', '', gr.update(interactive=False), gr.update(interactive=True), gr.update(interactive=True), gr.update()
 
     stream = AsyncStream()
+    stream_listener_active = False
 
     # stream作成後、バッチ処理前もう一度フラグを確認
     if batch_stopped:
@@ -2833,6 +2836,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         )
         generation_active = False
         stream = AsyncStream()
+        stream_listener_active = False
         return
 
     # バッチ処理ループの開始
@@ -3104,8 +3108,10 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
         # 現在のバッチの処理結果を取得
         listener_queue = stream.output_queue.subscribe()
-        while True:
-            flag, data = listener_queue.next()
+        stream_listener_active = True
+        try:
+            while True:
+                flag, data = listener_queue.next()
 
             if flag == 'file':
                 batch_output_filename = data
@@ -3197,6 +3203,8 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                         gr.update()
                     )
                 break
+        finally:
+            stream_listener_active = False
 
         # 最終的な出力ファイル名を更新
         output_filename = batch_output_filename
@@ -3208,6 +3216,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
     generation_active = False
     stream = AsyncStream()
+    stream_listener_active = False
 
 def end_process():
     global stream
@@ -3251,7 +3260,7 @@ def end_after_step_process():
 def resync_status_handler():
     """Resume streaming progress after page reload."""
     global last_progress_desc, last_progress_bar, last_preview_image, last_output_filename
-    global current_seed, generation_active, stream
+    global current_seed, generation_active, stream, stream_listener_active
 
     running = is_generation_running()
     yield (
@@ -3265,10 +3274,11 @@ def resync_status_handler():
         gr.update(value=current_seed),
     )
 
-    if not running or stream is None or not hasattr(stream, "output_queue"):
+    if not running or stream is None or not hasattr(stream, "output_queue") or stream_listener_active:
         return
 
     listener_queue = stream.output_queue.subscribe()
+    stream_listener_active = True
     while True:
         try:
             flag, data = listener_queue.next()
@@ -3313,6 +3323,7 @@ def resync_status_handler():
                 stream.output_queue.clear()
             except Exception:
                 stream = AsyncStream()
+            stream_listener_active = False
             return
 
     # If we exit the loop without receiving an 'end' flag, ensure the state is reset
@@ -3330,6 +3341,7 @@ def resync_status_handler():
         stream.output_queue.clear()
     except Exception:
         stream = AsyncStream()
+    stream_listener_active = False
 
 def end_after_step_process():
     """現在のステップ完了後に停止する処理"""


### PR DESCRIPTION
## Summary
- track active stream listener and ignore unnecessary resync requests
- recreate stream listener on demand so progress can resume after connection loss

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689526b73d30832fb0d7e7e0e2f3130e