### PR TITLE
Fix modal preview button root detection

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3373,12 +3373,13 @@ with block:
       <img id='orig_size_img'>
     </div>
     <script>
+    const scriptRoot=document.currentScript?.getRootNode?.()||document;
     function setupOrigSize(){
-      const app=document.querySelector('gradio-app');
-      const root=app&&app.shadowRoot?app.shadowRoot:document;
+      const root=scriptRoot;
       const modal=root.getElementById('orig_size_modal');
       const imgElem=root.getElementById('orig_size_img');
       const closeBtn=root.getElementById('orig_size_close');
+      if(!modal||!imgElem||!closeBtn) return;
       closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
       function addButtons(){
 

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4513,12 +4513,13 @@ with block:
       <img id='orig_size_img'>
     </div>
     <script>
+    const scriptRoot=document.currentScript?.getRootNode?.()||document;
     function setupOrigSize(){
-      const app=document.querySelector('gradio-app');
-      const root=app&&app.shadowRoot?app.shadowRoot:document;
+      const root=scriptRoot;
       const modal=root.getElementById('orig_size_modal');
       const imgElem=root.getElementById('orig_size_img');
       const closeBtn=root.getElementById('orig_size_close');
+      if(!modal||!imgElem||!closeBtn) return;
       closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
       function addButtons(){
         const selector='button[aria-label="VIEW_IN_FULL_SCREEN_LABEL"],button[title="VIEW_IN_FULL_SCREEN_LABEL"],button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]';

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3225,12 +3225,13 @@ with block:
       <img id='orig_size_img'>
     </div>
     <script>
+    const scriptRoot=document.currentScript?.getRootNode?.()||document;
     function setupOrigSize(){
-      const app=document.querySelector('gradio-app');
-      const root=app&&app.shadowRoot?app.shadowRoot:document;
+      const root=scriptRoot;
       const modal=root.getElementById('orig_size_modal');
       const imgElem=root.getElementById('orig_size_img');
       const closeBtn=root.getElementById('orig_size_close');
+      if(!modal||!imgElem||!closeBtn) return;
       closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
       function addButtons(){
         const selector='button[aria-label="VIEW_IN_FULL_SCREEN_LABEL"],button[title="VIEW_IN_FULL_SCREEN_LABEL"],button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]';


### PR DESCRIPTION
## Summary
- ensure modal preview buttons work with Gradio's shadow DOM by using `document.currentScript.getRootNode()`
- avoid null errors and missing icons when fullscreen labels differ

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954775b038832fa6b293c2c8132fd3