### PR TITLE
Improve spinner output and remove duplicate startup log

### DIFF
--- a/webui/eichi_utils/spinner.py
+++ b/webui/eichi_utils/spinner.py
@@ -37,16 +37,16 @@ def spinner_while_running(message, function, *args, **kwargs):
 
     def spinner():
         with lock:
-            original_stdout.write(f"{next(spinner_cycle)}  {message}\n")
+            original_stdout.write(f"{next(spinner_cycle)}  {message}")
             original_stdout.flush()
         while not done.is_set():
             time.sleep(0.1)
             with lock:
-                original_stdout.write("\x1b[1A\r\x1b[2K")
-                original_stdout.write(f"{next(spinner_cycle)}  {message}\n")
+                original_stdout.write("\r\x1b[K")
+                original_stdout.write(f"{next(spinner_cycle)}  {message}")
                 original_stdout.flush()
         with lock:
-            original_stdout.write("\x1b[1A\r\x1b[2K")
+            original_stdout.write("\r\x1b[K")
             original_stdout.write(f"✅ {message}\n")
             original_stdout.flush()
 

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3195,11 +3195,6 @@ startup_prompt = spinner_while_running(
     translate("Load_startup_default_prompt"),
     get_default_startup_prompt,
 )
-print(
-    translate("起動時デフォルトプロンプトを読み込み: '{0}'... (長さ: {1}文字)").format(
-        startup_prompt[:30], len(startup_prompt)
-    )
-)
 
 # 読み込んだ設定をログに出力
 if saved_app_settings:


### PR DESCRIPTION
## Summary
- prevent spinner artifact lines by updating spinner to redraw in-place
- avoid duplicate startup prompt logs in webui startup sequence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689556485980832f9192387997e81095