### PR TITLE
fix: stabilize modal preview

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3423,7 +3423,10 @@ with block:
       }
       addButtons();
       const obs=new MutationObserver(addButtons);
-      obs.observe(root,{childList:true,subtree:true,attributes:true});
+      // Limiting observation to structural changes prevents attribute
+      // mutations from triggering extra upload events that previously caused
+      // console errors and blocked the image modal preview.
+      obs.observe(root,{childList:true,subtree:true});
     }
     if(document.readyState !== 'loading'){
       setupOrigSize();

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4561,7 +4561,12 @@ with block:
       }
       addButtons();
       const obs=new MutationObserver(addButtons);
-      obs.observe(root,{childList:true,subtree:true,attributes:true});
+      // Watching attribute mutations caused unnecessary stream activity
+      // during image uploads which resulted in "Method not implemented" and
+      // "Too many arguments" errors in the browser. Restrict observation to
+      // structural DOM changes so modal preview buttons can be inserted
+      // without interfering with Gradio's upload process.
+      obs.observe(root,{childList:true,subtree:true});
     }
     if(document.readyState !== 'loading'){
       setupOrigSize();

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3267,7 +3267,12 @@ with block:
       }
       addButtons();
       const obs=new MutationObserver(addButtons);
-      obs.observe(root,{childList:true,subtree:true,attributes:true});
+      // Observing attribute mutations triggered excessive "upload" events in
+      // Gradio's image components which caused console errors like
+      // "Too many arguments provided for the endpoint" when an image was
+      // added.  We only need to track structural changes to insert the modal
+      // preview buttons, so limit observation to childList/subtree updates.
+      obs.observe(root,{childList:true,subtree:true});
     }
     if(document.readyState !== 'loading'){
       setupOrigSize();


### PR DESCRIPTION
## Summary
- restrict MutationObserver to structural changes to avoid interference with Gradio image uploads
- document reason for removing attribute observation across modal preview scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955b403d0c832fa9dbd67f0c806831