### PR TITLE
fix: open folders on Windows

### DIFF
--- a/version/v1.9.3/webui/eichi_utils/settings_manager.py
+++ b/version/v1.9.3/webui/eichi_utils/settings_manager.py
@@ -89,7 +89,10 @@ def open_output_folder(folder_path):
 
     try:
         if os.name == 'nt':  # Windows
-            subprocess.Popen(['explorer', folder_path])
+            try:
+                os.startfile(folder_path)
+            except Exception:
+                subprocess.Popen(['explorer', folder_path])
             print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None

--- a/version/v1.9.3/webui/oneframe_ichi.py
+++ b/version/v1.9.3/webui/oneframe_ichi.py
@@ -164,7 +164,10 @@ def open_folder(folder_path):
 
     try:
         if os.name == 'nt':  # Windows
-            subprocess.Popen(['explorer', folder_path])
+            try:
+                os.startfile(folder_path)
+            except Exception:
+                subprocess.Popen(['explorer', folder_path])
             print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None

--- a/webui/eichi_utils/log_manager.py
+++ b/webui/eichi_utils/log_manager.py
@@ -270,7 +270,10 @@ def open_log_folder():
     
     try:
         if os.name == 'nt':  # Windows
-            subprocess.Popen(['explorer', folder_path])
+            try:
+                os.startfile(folder_path)
+            except Exception:
+                subprocess.Popen(['explorer', folder_path])
             print(translate("ログフォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -117,7 +117,10 @@ def open_output_folder(folder_path):
 
     try:
         if os.name == 'nt':  # Windows
-            subprocess.Popen(['explorer', folder_path])
+            try:
+                os.startfile(folder_path)
+            except Exception:
+                subprocess.Popen(['explorer', folder_path])
             print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -404,7 +404,10 @@ def open_folder(folder_path):
 
     try:
         if os.name == 'nt':  # Windows環境
-            subprocess.Popen(['explorer', folder_path])
+            try:
+                os.startfile(folder_path)
+            except Exception:
+                subprocess.Popen(['explorer', folder_path])
             print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             opener = None


### PR DESCRIPTION
## Summary
- ensure 'open folder' buttons work on Windows by using `os.startfile` before falling back to `explorer`
- update settings and log utilities accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68958b6b9a54832faf59243756418de8