### PR TITLE
Skip modal button injection on upload widgets to fix icon errors

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3391,7 +3391,10 @@ with block:
           const fullBtn=toolbar?toolbar.querySelector(selector):null;
           const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
           const img=container?container.querySelector('img'):null;
-          if(!toolbar||!fullBtn||!img) btn.remove();
+          const fileInput=container?container.querySelector('input[type="file"]'):null;
+          // Drop buttons if their image is missing or if they belong to an
+          // upload widget (identified by the presence of a file input)
+          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
         });
         // 新規ボタンの追加
 
@@ -3400,7 +3403,10 @@ with block:
           if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
           const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
           const img=container.querySelector('img');
-          if(!img||!img.src) return;
+          const fileInput=container.querySelector('input[type="file"]');
+          // Skip adding modal buttons to input images to avoid triggering
+          // errors in Gradio's upload handling when the DOM is mutated.
+          if(!img||!img.src||fileInput) return;
 
           const btn=document.createElement('button');
           btn.className=fullBtn.className;

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4529,7 +4529,9 @@ with block:
           const fullBtn=toolbar?toolbar.querySelector(selector):null;
           const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
           const img=container?container.querySelector('img'):null;
-          if(!toolbar||!fullBtn||!img) btn.remove();
+          const fileInput=container?container.querySelector('input[type="file"]'):null;
+          // Remove orphaned buttons or those inside upload components
+          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
         });
         // 新規ボタンの追加
 
@@ -4538,7 +4540,10 @@ with block:
           if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
           const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
           const img=container.querySelector('img');
-          if(!img||!img.src) return;
+          const fileInput=container.querySelector('input[type="file"]');
+          // Input image widgets include a file input element; skip them to
+          // avoid interfering with Gradio's upload mechanism.
+          if(!img||!img.src||fileInput) return;
 
           const btn=document.createElement('button');
           btn.className=fullBtn.className;

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3239,7 +3239,10 @@ with block:
           const fullBtn=toolbar?toolbar.querySelector(selector):null;
           const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
           const img=container?container.querySelector('img'):null;
-          if(!toolbar||!fullBtn||!img) btn.remove();
+          const fileInput=container?container.querySelector('input[type="file"]'):null;
+          // Remove buttons that have lost their associated image or belong to
+          // upload components (which contain a file input element)
+          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
         });
         // 新規ボタンの追加
         root.querySelectorAll(selector).forEach(fullBtn=>{
@@ -3247,7 +3250,10 @@ with block:
           if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
           const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
           const img=container.querySelector('img');
-          if(!img||!img.src) return;
+          const fileInput=container.querySelector('input[type="file"]');
+          // Skip input image components to avoid interfering with Gradio's
+          // upload widgets, which caused console errors when mutated.
+          if(!img||!img.src||fileInput) return;
 
           const btn=document.createElement('button');
           btn.className=fullBtn.className;


### PR DESCRIPTION
## Summary
- avoid adding custom view-modal buttons to Gradio image upload components
- clean up stray buttons when an image is missing or belongs to an upload widget
- apply fix across one-frame and end-frame scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895a5a2643c832fafab85feaa6852fb