### PR TITLE
Prevent seed loss on status resync

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3262,7 +3262,7 @@ def resync_status_handler():
         gr.update(interactive=not running, value=translate("Start Generation")),
         gr.update(interactive=running, value=translate("End Generation")),
         gr.update(interactive=running),
-        gr.update(value=current_seed),
+        gr.update(value=current_seed) if current_seed is not None else gr.skip(),
     )
 
     if not running or stream is None or not hasattr(stream, "output_queue"):
@@ -3286,7 +3286,7 @@ def resync_status_handler():
                 gr.update(interactive=False),
                 gr.update(interactive=True),
                 gr.update(interactive=True),
-                gr.update(value=current_seed),
+                gr.update(value=current_seed) if current_seed is not None else gr.skip(),
             )
 
         if flag == 'progress':
@@ -3294,7 +3294,7 @@ def resync_status_handler():
             last_preview_image = preview
             last_progress_desc = desc
             last_progress_bar = html
-            yield gr.skip(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update(interactive=True), gr.update(value=current_seed)
+            yield gr.skip(), gr.update(visible=True, value=preview), desc, html, gr.update(interactive=False), gr.update(interactive=True), gr.update(interactive=True), gr.update(value=current_seed) if current_seed is not None else gr.skip()
 
         if flag == 'end':
             generation_active = False
@@ -3307,7 +3307,7 @@ def resync_status_handler():
                 gr.update(interactive=True, value=translate("Start Generation")),
                 gr.update(interactive=False, value=translate("End Generation")),
                 gr.update(interactive=False),
-                gr.update(value=current_seed),
+                gr.update(value=current_seed) if current_seed is not None else gr.skip(),
             )
             try:
                 stream.output_queue.clear()
@@ -3324,7 +3324,7 @@ def resync_status_handler():
         gr.update(interactive=True, value=translate("Start Generation")),
         gr.update(interactive=False, value=translate("End Generation")),
         gr.update(interactive=False),
-        gr.update(value=current_seed),
+        gr.update(value=current_seed) if current_seed is not None else gr.skip(),
     )
     try:
         stream.output_queue.clear()

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3108,7 +3108,7 @@ def resync_status_handler():
         gr.update(interactive=running, value=translate("End Generation")),
         gr.update(interactive=running),
         gr.update(interactive=running),
-        gr.update(value=current_seed),
+        gr.update(value=current_seed) if current_seed is not None else gr.skip(),
     )
 
     if not running or stream is None or not hasattr(stream, "output_queue"):
@@ -3133,7 +3133,7 @@ def resync_status_handler():
                 gr.update(interactive=True),
                 gr.update(interactive=True),
                 gr.update(interactive=True),
-                gr.update(value=current_seed),
+                gr.update(value=current_seed) if current_seed is not None else gr.skip(),
             )
 
         if flag == 'progress':
@@ -3155,7 +3155,7 @@ def resync_status_handler():
                 gr.update(interactive=False, value=translate("End Generation")),
                 gr.update(interactive=False),
                 gr.update(interactive=False),
-                gr.update(value=current_seed),
+                gr.update(value=current_seed) if current_seed is not None else gr.skip(),
             )
             try:
                 stream.output_queue.clear()
@@ -3173,7 +3173,7 @@ def resync_status_handler():
         gr.update(interactive=False, value=translate("End Generation")),
         gr.update(interactive=False),
         gr.update(interactive=False),
-        gr.update(value=current_seed),
+        gr.update(value=current_seed) if current_seed is not None else gr.skip(),
     )
     try:
         stream.output_queue.clear()


### PR DESCRIPTION
## Summary
- Preserve seed value when resynchronizing status to avoid clearing user input
- Ensure newly opened generation pages retain original seed settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a6072bbc832f8432b1e70457b31f