### PR TITLE
feat: add modal image preview

### DIFF
--- a/webui/eichi_utils/ui_styles.py
+++ b/webui/eichi_utils/ui_styles.py
@@ -208,42 +208,4 @@ def get_app_css():
         border: solid 1px;
     }
 
-    /* ===== 原寸大表示モーダル ===== */
-    #orig_size_modal {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        background: rgba(0, 0, 0, 0.8);
-        display: none;
-        align-items: center;
-        justify-content: center;
-        z-index: 1000;
-    }
-
-    #orig_size_modal.visible {
-        display: flex;
-    }
-
-    #orig_size_modal img {
-        max-width: 90%;
-        max-height: 90%;
-    }
-
-    #orig_size_close {
-        position: absolute;
-        top: 20px;
-        right: 30px;
-        background: none;
-        border: none;
-        color: white;
-        font-size: 2rem;
-        cursor: pointer;
-    }
-    .view-modal-screen-btn {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
     """

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3347,6 +3347,8 @@ quick_prompts = [
 quick_prompts = [[x] for x in quick_prompts]
 
 css = get_app_css()
+with open(os.path.join(os.path.dirname(__file__), "modal.css")) as f:
+    css += f.read()
 
 # アプリケーション起動時に保存された設定を読み込む
 from eichi_utils.settings_manager import load_app_settings
@@ -3354,90 +3356,13 @@ saved_app_settings = load_app_settings()
 if saved_app_settings:
     lora_state_cache.set_cache_enabled(saved_app_settings.get("lora_cache", False))
 
-block = gr.Blocks(css=css).queue()
+with open(os.path.join(os.path.dirname(__file__), "modal.js"), encoding="utf-8") as f:
+    modal_js = f.read()
+
+block = gr.Blocks(css=css, js=modal_js).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-eichi</span></h1>')
-
-    # 原寸大表示用モーダルとボタン追加スクリプト
-    fullscreen_label = translate("View in full screen")
-    orig_size_script = """
-    <div id='orig_size_modal'>
-      <button id='orig_size_close'>×</button>
-      <img id='orig_size_img'>
-    </div>
-    <script>
-    const scriptRoot=document.currentScript?.getRootNode?.()||document;
-    function setupOrigSize(){
-      const root=scriptRoot;
-      const modal=root.getElementById('orig_size_modal');
-      const imgElem=root.getElementById('orig_size_img');
-      const closeBtn=root.getElementById('orig_size_close');
-      if(!modal||!imgElem||!closeBtn) return;
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-
-        const selector='button[aria-label="VIEW_IN_FULL_SCREEN_LABEL"],button[title="VIEW_IN_FULL_SCREEN_LABEL"],button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]';
-
-        // 既存ボタンのクリーンアップ
-        root.querySelectorAll('.view-modal-screen-btn').forEach(btn=>{
-          const toolbar=btn.parentElement;
-          const fullBtn=toolbar?toolbar.querySelector(selector):null;
-          const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
-          const img=container?container.querySelector('img'):null;
-          const fileInput=container?container.querySelector('input[type="file"]'):null;
-          // Drop buttons if their image is missing or if they belong to an
-          // upload widget (identified by the presence of a file input)
-          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
-        });
-        // 新規ボタンの追加
-
-        root.querySelectorAll(selector).forEach(fullBtn=>{
-          const toolbar=fullBtn.parentElement;
-          if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
-          const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
-          const img=container.querySelector('img');
-          const fileInput=container.querySelector('input[type="file"]');
-          // Skip adding modal buttons to input images to avoid triggering
-          // errors in Gradio's upload handling when the DOM is mutated.
-          if(!img||!img.src||fileInput) return;
-
-          const btn=document.createElement('button');
-          btn.className=fullBtn.className;
-          btn.classList.add('view-modal-screen-btn');
-          btn.setAttribute('aria-label','View modal screen');
-          btn.setAttribute('aria-haspopup','false');
-          btn.title='View modal screen';
-          btn.style.color='var(--block-label-text-color)';
-          btn.style.setProperty('--bg-color','var(--block-background-fill)');
-          const inner=fullBtn.querySelector('div');
-          const innerClass=inner?inner.className:'';
-          btn.innerHTML=`<div class="${innerClass}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%">
-      <path fill="currentColor" fill-rule="evenodd" d="M0 0H24V24H0Z M4.32 4.32H19.68V19.68H4.32Z"/>
-    </svg>
-  </div>`;
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, fullBtn);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      // Watching attribute changes on Gradio's image upload components
-      // causes extra network traffic which surfaces "Method not
-      // implemented" and "Too many arguments" errors in the console. We
-      // only need to react to structural updates, so observe child list
-      // mutations and ignore attributes.
-      const mutationOptions={childList:true,subtree:true};
-      obs.observe(root, mutationOptions);
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
-    """
-    gr.HTML(orig_size_script.replace("VIEW_IN_FULL_SCREEN_LABEL", fullscreen_label))
+    gr.HTML('<dialog id="modal_dlg"><img /></dialog>')
 
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置
     with gr.Row():
@@ -3496,7 +3421,14 @@ with block:
         with gr.Column():
             # Final Frameの上に説明を追加
             gr.Markdown(translate("**Finalは最後の画像、Imageは最初の画像(最終キーフレーム画像といずれか必須)となります。**"))
-            end_frame = gr.Image(sources=['upload', 'clipboard'], type="filepath", label=translate("Final Frame (Optional)"), height=320)
+            end_frame = gr.Image(
+                sources=['upload', 'clipboard'],
+                type="filepath",
+                label=translate("Final Frame (Optional)"),
+                height=320,
+                elem_id="end_frame_image",
+                elem_classes="modal-image",
+            )
 
             # テンソルデータ設定をグループ化して灰色のタイトルバーに変更
             with gr.Group():
@@ -3986,7 +3918,13 @@ with block:
 
                             # 右側にキーフレーム画像のみ配置
                             with gr.Column(scale=2):
-                                section_image = gr.Image(label=translate("キーフレーム画像 {0}").format(i), sources="upload", type="filepath", height=200)
+                                section_image = gr.Image(
+                                    label=translate("キーフレーム画像 {0}").format(i),
+                                    sources="upload",
+                                    type="filepath",
+                                    height=200,
+                                    elem_classes="modal-image",
+                                )
 
                                 # プロンプト変更時にStateを更新するハンドラー
                                 def update_prompt_state(prompt_value, section_idx=i):
@@ -4201,7 +4139,14 @@ with block:
                         outputs=[section_image_inputs[0], section_image_inputs[1]]
                     )
 
-            input_image = gr.Image(sources=['upload', 'clipboard'], type="filepath", label="Image", height=320)
+            input_image = gr.Image(
+                sources=['upload', 'clipboard'],
+                type="filepath",
+                label="Image",
+                height=320,
+                elem_id="input_image",
+                elem_classes="modal-image",
+            )
 
             # メタデータ抽出関数を定義（後で登録する）
             def update_from_image_metadata(image_path, copy_enabled=False):
@@ -5556,7 +5501,13 @@ with block:
             )
             progress_desc = gr.Markdown('', elem_classes='no-generating-animation')
             progress_bar = gr.HTML('', elem_classes='no-generating-animation')
-            preview_image = gr.Image(label=translate("Next Latents"), height=200, visible=False)
+            preview_image = gr.Image(
+                label=translate("Next Latents"),
+                height=200,
+                visible=False,
+                elem_id="preview_image",
+                elem_classes="modal-image",
+            )
 
             # フレームサイズ切替用のUIコントロールは上部に移動したため削除
 

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4495,87 +4495,14 @@ quick_prompts = [
 quick_prompts = [[x] for x in quick_prompts]
 
 css = get_app_css()
-block = gr.Blocks(css=css).queue()
+with open(os.path.join(os.path.dirname(__file__), "modal.css")) as f:
+    css += f.read()
+with open(os.path.join(os.path.dirname(__file__), "modal.js"), encoding="utf-8") as f:
+    modal_js = f.read()
+block = gr.Blocks(css=css, js=modal_js).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-<s>eichi</s> F1</span></h1>')
-
-    # 原寸大表示用モーダルとボタン追加スクリプト
-    fullscreen_label = translate("View in full screen")
-    orig_size_script = """
-    <div id='orig_size_modal'>
-      <button id='orig_size_close'>×</button>
-      <img id='orig_size_img'>
-    </div>
-    <script>
-    const scriptRoot=document.currentScript?.getRootNode?.()||document;
-    function setupOrigSize(){
-      const root=scriptRoot;
-      const modal=root.getElementById('orig_size_modal');
-      const imgElem=root.getElementById('orig_size_img');
-      const closeBtn=root.getElementById('orig_size_close');
-      if(!modal||!imgElem||!closeBtn) return;
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-        const selector='button[aria-label="VIEW_IN_FULL_SCREEN_LABEL"],button[title="VIEW_IN_FULL_SCREEN_LABEL"],button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]';
-        // 既存ボタンのクリーンアップ
-        root.querySelectorAll('.view-modal-screen-btn').forEach(btn=>{
-          const toolbar=btn.parentElement;
-          const fullBtn=toolbar?toolbar.querySelector(selector):null;
-          const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
-          const img=container?container.querySelector('img'):null;
-          const fileInput=container?container.querySelector('input[type="file"]'):null;
-          // Remove orphaned buttons or those inside upload components
-          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
-        });
-        // 新規ボタンの追加
-
-        root.querySelectorAll(selector).forEach(fullBtn=>{
-          const toolbar=fullBtn.parentElement;
-          if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
-          const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
-          const img=container.querySelector('img');
-          const fileInput=container.querySelector('input[type="file"]');
-          // Input image widgets include a file input element; skip them to
-          // avoid interfering with Gradio's upload mechanism.
-          if(!img||!img.src||fileInput) return;
-
-          const btn=document.createElement('button');
-          btn.className=fullBtn.className;
-          btn.classList.add('view-modal-screen-btn');
-          btn.setAttribute('aria-label','View modal screen');
-          btn.setAttribute('aria-haspopup','false');
-          btn.title='View modal screen';
-          btn.style.color='var(--block-label-text-color)';
-          btn.style.setProperty('--bg-color','var(--block-background-fill)');
-          const inner=fullBtn.querySelector('div');
-          const innerClass=inner?inner.className:'';
-          btn.innerHTML=`<div class="${innerClass}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%">
-      <path fill="currentColor" fill-rule="evenodd" d="M0 0H24V24H0Z M4.32 4.32H19.68V19.68H4.32Z"/>
-    </svg>
-  </div>`;
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, fullBtn);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      // Watching attribute mutations caused unnecessary stream activity
-      // during image uploads which resulted in "Method not implemented" and
-      // "Too many arguments" errors in the browser. Restrict observation to
-      // structural DOM changes so modal preview buttons can be inserted
-      // without interfering with Gradio's upload process.
-      const mutationOptions={childList:true,subtree:true};
-      obs.observe(root, mutationOptions);
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
-    """
-    gr.HTML(orig_size_script.replace("VIEW_IN_FULL_SCREEN_LABEL", fullscreen_label))
+    gr.HTML('<dialog id="modal_dlg"><img /></dialog>')
 
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置
     with gr.Row():
@@ -4625,7 +4552,14 @@ with block:
 
     with gr.Row():
         with gr.Column():
-            input_image = gr.Image(sources=['upload', 'clipboard'], type="filepath", label="Image", height=320)
+            input_image = gr.Image(
+                sources=['upload', 'clipboard'],
+                type="filepath",
+                label="Image",
+                height=320,
+                elem_id="input_image",
+                elem_classes="modal-image",
+            )
 
             # テンソルデータ設定をグループ化して灰色のタイトルバーに変更
             with gr.Group():
@@ -5634,7 +5568,13 @@ with block:
             )
             progress_desc = gr.Markdown('', elem_classes='no-generating-animation')
             progress_bar = gr.HTML('', elem_classes='no-generating-animation')
-            preview_image = gr.Image(label="Next Latents", height=200, visible=False)
+            preview_image = gr.Image(
+                label="Next Latents",
+                height=200,
+                visible=False,
+                elem_id="preview_image",
+                elem_classes="modal-image",
+            )
 
             # フレームサイズ切替用のUIコントロールは上部に移動したため削除
 

--- a/webui/modal.css
+++ b/webui/modal.css
@@ -1,0 +1,18 @@
+#modal_dlg {
+  border: none;
+  padding: 0;
+  background: none;
+}
+#modal_dlg::backdrop {
+  background: rgba(0,0,0,0.8);
+}
+#modal_dlg img {
+  max-width: 90vw;
+  max-height: 90vh;
+}
+.icon-button-wrapper .view-modal-btn,
+.gr-image__tool .view-modal-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}

--- a/webui/modal.js
+++ b/webui/modal.js
@@ -1,0 +1,43 @@
+(() => {
+  function init() {
+    const dialog = document.getElementById("modal_dlg");
+    if (!dialog) return;
+    const dialogImg = dialog.querySelector("img");
+    dialog.addEventListener("click", () => dialog.close());
+    dialog.addEventListener("close", () => {
+      dialogImg.src = "";
+    });
+    document.querySelectorAll(".modal-image").forEach((host) => {
+      const bar = host.querySelector(".icon-button-wrapper") || host.querySelector(".gr-image__tool");
+      if (!bar) return;
+      function addBtn() {
+        if (bar.querySelector(".view-modal-btn")) return;
+        const fullBtn = bar.querySelector(
+          'button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]'
+        );
+        const img = host.querySelector("img");
+        if (!fullBtn || !img) return;
+        const inner = fullBtn.querySelector("div");
+        const innerClass = inner ? inner.className : "";
+        const btn = document.createElement("button");
+        btn.className = fullBtn.className + " view-modal-btn";
+        btn.setAttribute("aria-label", "View modal screen");
+        btn.title = "View modal screen";
+        btn.innerHTML = `<div class="${innerClass}">\n  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%">\n    <path fill="currentColor" d="M4 4h16v16H4z"/>\n  </svg>\n</div>`;
+        btn.onclick = () => {
+          dialogImg.src = img.src;
+          dialog.showModal();
+        };
+        bar.insertBefore(btn, fullBtn);
+      }
+      addBtn();
+      const obs = new MutationObserver(addBtn);
+      obs.observe(bar, { childList: true });
+    });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3169,6 +3169,10 @@ def resync_status_handler():
         pass
 
 css = get_app_css()  # eichi_utilsのスタイルを使用
+with open(os.path.join(os.path.dirname(__file__), "modal.css")) as f:
+    css += f.read()
+with open(os.path.join(os.path.dirname(__file__), "modal.js"), encoding="utf-8") as f:
+    modal_js = f.read()
 
 # アプリケーション起動時に保存された設定を読み込む
 saved_app_settings = load_app_settings_oichi()
@@ -3198,89 +3202,11 @@ print("\n------------------------------------------------------------")
 print(f"🆗 {translate('Startup_sequence_complete')}\n")
 # △ 起動シーケンスここまで △
 
-block = gr.Blocks(css=css).queue()
+block = gr.Blocks(css=css, js=modal_js).queue()
 with block:
     # eichiと同じ半透明度スタイルを使用
     gr.HTML('<h1>FramePack<span class="title-suffix">-oichi</span></h1>')
-
-    # 原寸大表示用モーダルとボタン追加スクリプト
-    fullscreen_label = translate("View in full screen")
-    orig_size_script = """
-    <div id='orig_size_modal'>
-      <button id='orig_size_close'>×</button>
-      <img id='orig_size_img'>
-    </div>
-    <script>
-    const scriptRoot=document.currentScript?.getRootNode?.()||document;
-    function setupOrigSize(){
-      const root=scriptRoot;
-      const modal=root.getElementById('orig_size_modal');
-      const imgElem=root.getElementById('orig_size_img');
-      const closeBtn=root.getElementById('orig_size_close');
-      if(!modal||!imgElem||!closeBtn) return;
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-        const selector='button[aria-label="VIEW_IN_FULL_SCREEN_LABEL"],button[title="VIEW_IN_FULL_SCREEN_LABEL"],button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]';
-        // 既存ボタンのクリーンアップ
-        root.querySelectorAll('.view-modal-screen-btn').forEach(btn=>{
-          const toolbar=btn.parentElement;
-          const fullBtn=toolbar?toolbar.querySelector(selector):null;
-          const container=toolbar?toolbar.closest('[data-testid="image"]')||toolbar.parentElement:null;
-          const img=container?container.querySelector('img'):null;
-          const fileInput=container?container.querySelector('input[type="file"]'):null;
-          // Remove buttons that have lost their associated image or belong to
-          // upload components (which contain a file input element)
-          if(!toolbar||!fullBtn||!img||fileInput) btn.remove();
-        });
-        // 新規ボタンの追加
-        root.querySelectorAll(selector).forEach(fullBtn=>{
-          const toolbar=fullBtn.parentElement;
-          if(!toolbar||toolbar.querySelector('.view-modal-screen-btn')) return;
-          const container=toolbar.closest('[data-testid="image"]')||toolbar.parentElement;
-          const img=container.querySelector('img');
-          const fileInput=container.querySelector('input[type="file"]');
-          // Skip input image components to avoid interfering with Gradio's
-          // upload widgets, which caused console errors when mutated.
-          if(!img||!img.src||fileInput) return;
-
-          const btn=document.createElement('button');
-          btn.className=fullBtn.className;
-          btn.classList.add('view-modal-screen-btn');
-          btn.setAttribute('aria-label','View modal screen');
-          btn.setAttribute('aria-haspopup','false');
-          btn.title='View modal screen';
-          btn.style.color='var(--block-label-text-color)';
-          btn.style.setProperty('--bg-color','var(--block-background-fill)');
-          const inner=fullBtn.querySelector('div');
-          const innerClass=inner?inner.className:'';
-          btn.innerHTML=`<div class="${innerClass}">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%">
-      <path fill="currentColor" fill-rule="evenodd" d="M0 0H24V24H0Z M4.32 4.32H19.68V19.68H4.32Z"/>
-    </svg>
-  </div>`;
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, fullBtn);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      // Observing attribute mutations triggered excessive upload requests in
-      // Gradio's image components which surfaced console errors such as
-      // "Too many arguments provided for the endpoint" and "Method not
-      // implemented" when images were added or replaced. Track only
-      // structural changes so the modal buttons can be injected without
-      // disturbing the upload widget.
-      const mutationOptions={childList:true,subtree:true};
-      obs.observe(root, mutationOptions);
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
-    """
-    gr.HTML(orig_size_script.replace("VIEW_IN_FULL_SCREEN_LABEL", fullscreen_label))
+    gr.HTML('<dialog id="modal_dlg"><img /></dialog>')
     
     # 初期化時にtransformerの状態確認は行わない（必要時に遅延ロード）
     # ここではロードをスキップして、ワーカー関数内で必要になったときにだけロードする
@@ -3297,7 +3223,14 @@ with block:
             # モードについての説明を画像枠の上に表示
             gr.Markdown(translate("**「1フレーム推論」モードでは、1枚の新しい未来の画像を生成します。**"))
             
-            input_image = gr.Image(sources=['upload', 'clipboard'], type="filepath", label=translate("Image"), height=320)
+            input_image = gr.Image(
+                sources=['upload', 'clipboard'],
+                type="filepath",
+                label=translate("Image"),
+                height=320,
+                elem_id="input_image",
+                elem_classes="modal-image",
+            )
             
             # 解像度設定（画像の直下に）
             resolution = gr.Dropdown(
@@ -3566,7 +3499,9 @@ with block:
                 type="filepath",
                 interactive=True,
                 visible=use_reference_image_default,  # 保存設定に基づき初期表示
-                height=320
+                height=320,
+                elem_id="reference_image",
+                elem_classes="modal-image",
             )
 
             # 参照画像キュー設定
@@ -4279,8 +4214,19 @@ with block:
                 
         with gr.Column(scale=1):
             # 右カラム - 生成結果と設定
-            result_image = gr.Image(label=translate("生成結果"), height=512)
-            preview_image = gr.Image(label=translate("処理中のプレビュー"), height=200, visible=False)
+            result_image = gr.Image(
+                label=translate("生成結果"),
+                height=512,
+                elem_id="result_image",
+                elem_classes="modal-image",
+            )
+            preview_image = gr.Image(
+                label=translate("処理中のプレビュー"),
+                height=200,
+                visible=False,
+                elem_id="preview_image",
+                elem_classes="modal-image",
+            )
             progress_desc = gr.Markdown('', elem_classes='no-generating-animation')
             progress_bar = gr.HTML('', elem_classes='no-generating-animation')
             


### PR DESCRIPTION
## Summary
- add reusable modal preview script and styles for Gradio images
- inject modal button via JS and apply to key image components
- remove legacy modal code
- load modal script inline to fix "framepack_nv20 is not defined" error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895b57c9b78832f8ea71e80e0a18ba2