### PR TITLE
Remove deprecated stream arg

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -5044,16 +5044,39 @@ with block:
         ]
     )
     
-    start_button.click(fn=process, inputs=ips, outputs=[result_image, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, stop_step_button, seed], stream=True)
+    start_button.click(
+        fn=process,
+        inputs=ips,
+        outputs=[
+            result_image,
+            preview_image,
+            progress_desc,
+            progress_bar,
+            start_button,
+            end_button,
+            stop_after_button,
+            stop_step_button,
+            seed,
+        ],
+    )
     end_button.click(fn=end_process, outputs=[end_button, stop_after_button, stop_step_button], queue=False)
     stop_after_button.click(fn=end_after_current_process, outputs=[stop_after_button, end_button], queue=False)
     stop_step_button.click(fn=end_after_step_process, outputs=[stop_step_button, end_button], queue=False)
     resync_status_btn.click(
         fn=resync_status_handler,
         inputs=[],
-        outputs=[result_image, preview_image, progress_desc, progress_bar, start_button, end_button, stop_after_button, stop_step_button, seed],
+        outputs=[
+            result_image,
+            preview_image,
+            progress_desc,
+            progress_bar,
+            start_button,
+            end_button,
+            stop_after_button,
+            stop_step_button,
+            seed,
+        ],
         queue=False,
-        stream=True
     )
     
     gr.HTML(f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")}</div>')


### PR DESCRIPTION
## Summary
- drop unsupported `stream=True` from gradio click handlers
- format handler definitions for readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c48691c0832f904b864189cd1a30