### PR TITLE
fix: load modal script content

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3357,8 +3357,10 @@ if saved_app_settings:
     lora_state_cache.set_cache_enabled(saved_app_settings.get("lora_cache", False))
 
 modal_js_path = os.path.join(os.path.dirname(__file__), "modal.js")
+with open(modal_js_path, encoding="utf8") as f:
+    modal_js = f.read()
 
-block = gr.Blocks(css=css, js=modal_js_path).queue()
+block = gr.Blocks(css=css, js=modal_js).queue()
 
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-eichi</span></h1>')

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4498,7 +4498,9 @@ css = get_app_css()
 with open(os.path.join(os.path.dirname(__file__), "modal.css")) as f:
     css += f.read()
 modal_js_path = os.path.join(os.path.dirname(__file__), "modal.js")
-block = gr.Blocks(css=css, js=modal_js_path).queue()
+with open(modal_js_path, encoding="utf8") as f:
+    modal_js = f.read()
+block = gr.Blocks(css=css, js=modal_js).queue()
 
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-<s>eichi</s> F1</span></h1>')

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3228,6 +3228,8 @@ css = get_app_css()  # eichi_utilsのスタイルを使用
 with open(os.path.join(os.path.dirname(__file__), "modal.css")) as f:
     css += f.read()
 modal_js_path = os.path.join(os.path.dirname(__file__), "modal.js")
+with open(modal_js_path, encoding="utf8") as f:
+    modal_js = f.read()
 
 
 # アプリケーション起動時に保存された設定を読み込む
@@ -3258,7 +3260,7 @@ print("\n------------------------------------------------------------")
 print(f"🆗 {translate('Startup_sequence_complete')}\n")
 # △ 起動シーケンスここまで △
 
-block = gr.Blocks(css=css, js=modal_js_path).queue()
+block = gr.Blocks(css=css, js=modal_js).queue()
 
 with block:
     # eichiと同じ半透明度スタイルを使用


### PR DESCRIPTION
## Summary
- load modal.js file contents and pass to Gradio Blocks for execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895cdb44254832f898415bddeebe877