### PR TITLE
Hide modal view icon when image removed

### DIFF
--- a/webui/modal.js
+++ b/webui/modal.js
@@ -13,8 +13,7 @@
       function addBtn() {
         if (bar.querySelector(".view-modal-btn")) return;
         const fullBtn = bar.querySelector('button[aria-label="View in full screen"],button[title="View in full screen"],button[aria-label="View fullscreen"],button[title="View fullscreen"],button[aria-label="View full screen"],button[title="View full screen"]');
-        const img = host.querySelector("img");
-        if (!fullBtn || !img) return;
+        if (!fullBtn) return;
         const inner = fullBtn.querySelector("div");
         const innerClass = inner ? inner.className : "";
         const btn = document.createElement("button");
@@ -22,11 +21,22 @@
         btn.setAttribute("aria-label", "View modal screen");
         btn.title = "View modal screen";
         btn.innerHTML = '<div class="' + innerClass + '"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%"><path fill="currentColor" d="M4 4h16v16H4z"/></svg></div>';
+        function updateBtn() {
+          const img = host.querySelector("img");
+          const hasImage = img && img.src;
+          btn.style.display = hasImage ? "" : "none";
+          btn.disabled = !hasImage;
+        }
         btn.onclick = () => {
+          const img = host.querySelector("img");
+          if (!img || !img.src) return;
           dialogImg.src = img.src;
           dialog.showModal();
         };
         bar.insertBefore(btn, fullBtn);
+        updateBtn();
+        const imgObs = new MutationObserver(updateBtn);
+        imgObs.observe(host, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
       }
       addBtn();
       const obs = new MutationObserver(addBtn);

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3695,7 +3695,8 @@ with block:
                             label=translate("入力画像マスク（オプション）"),
                             type="filepath",
                             interactive=True,
-                            height=320
+                            height=320,
+                            elem_classes="modal-image",
                         )
                         input_mask_info = gr.Markdown(
                             translate("白い部分を保持、黒い部分を変更（グレースケール画像）")
@@ -3708,7 +3709,8 @@ with block:
                             label=translate("参照画像マスク（オプション）"),
                             type="filepath",
                             interactive=True,
-                            height=320
+                            height=320,
+                            elem_classes="modal-image",
                         )
                         reference_mask_info = gr.Markdown(
                             translate("白い部分を適用、黒い部分を無視（グレースケール画像）")


### PR DESCRIPTION
## Summary
- hide modal icon when image deleted by observing src change
- allow modal viewing on input/reference masks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961955cfbc832f80845e630f118bb5