### PR TITLE
Ensure generation stops gracefully and shows last result

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3197,6 +3197,18 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # バッチ処理が停止されている場合はループを抜ける
         if batch_stopped:
             print(translate("バッチ処理ループを中断します"))
+            global last_output_filename
+            last_output_filename = batch_output_filename
+            yield (
+                batch_output_filename if batch_output_filename is not None else gr.skip(),
+                gr.update(value=None, visible=False),
+                translate("バッチ処理が中断されました"),
+                '',
+                gr.update(interactive=True),
+                gr.update(interactive=False, value=translate("End Generation")),
+                gr.update(interactive=False),
+                gr.update(),
+            )
             break
 
     generation_active = False


### PR DESCRIPTION
## Summary
- Notify background jobs when cancel buttons are pressed to halt generation promptly
- Preserve and display the last generated image when a batch is interrupted
- Display final output when endframe processing is stopped early

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68961f866edc832f8a0c8a8149e5032b