### PR TITLE
Remove redundant global declarations causing SyntaxError

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3102,7 +3102,6 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
 
             if flag == 'file':
                 batch_output_filename = data
-                global last_output_filename
                 last_output_filename = data
                 # より明確な更新方法を使用し、preview_imageを明示的にクリア
                 yield (
@@ -3197,7 +3196,6 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
         # バッチ処理が停止されている場合はループを抜ける
         if batch_stopped:
             print(translate("バッチ処理ループを中断します"))
-            global last_output_filename
             last_output_filename = batch_output_filename
             yield (
                 batch_output_filename if batch_output_filename is not None else gr.skip(),

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2992,7 +2992,6 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
                         print(translate("バッチ処理が中断されました（{0}/{1}）").format(batch_index_total + 1, total_batches))
                         # 直前に保存した画像を結果に反映
                         if output_filename is not None:
-                            global last_output_filename
                             last_output_filename = output_filename
                         # endframe_ichiと同様のシンプルな実装に戻す
                         progress_summary = f"参考画像 {progress_ref_idx}/{progress_ref_total} ,イメージ {progress_img_idx}/{progress_img_total}"


### PR DESCRIPTION
## Summary
- avoid SyntaxError by removing stray global statements in oneframe_ichi
- clean up redundant global declaration in endframe_ichi

## Testing
- `python -m py_compile webui/oneframe_ichi.py webui/endframe_ichi.py`
- `python webui/oneframe_ichi.py --port 7681` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689622ed3d10832f98d426899226e0c3