### PR TITLE
Fix WSL folder opening paths

### DIFF
--- a/tests/test_wsl_path_conversion.py
+++ b/tests/test_wsl_path_conversion.py
@@ -1,0 +1,63 @@
+import os
+import importlib.util
+import subprocess
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Load settings_manager module
+spec = importlib.util.spec_from_file_location(
+    'settings_manager', os.path.join(ROOT, 'webui', 'eichi_utils', 'settings_manager.py')
+)
+settings_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(settings_manager)
+
+# Load log_manager module
+spec_log = importlib.util.spec_from_file_location(
+    'log_manager', os.path.join(ROOT, 'webui', 'eichi_utils', 'log_manager.py')
+)
+log_manager = importlib.util.module_from_spec(spec_log)
+spec_log.loader.exec_module(log_manager)
+
+def test_open_output_folder_wsl(monkeypatch, tmp_path):
+    called = {}
+
+    monkeypatch.setattr(settings_manager, '_is_wsl', lambda: True)
+    monkeypatch.setattr(settings_manager.shutil, 'which', lambda cmd: 'explorer.exe' if cmd == 'explorer.exe' else None)
+
+    def mock_check_output(args):
+        called['check'] = args
+        return b'C:\\temp\\folder\n'
+
+    def mock_popen(args):
+        called['popen'] = args
+
+    monkeypatch.setattr(subprocess, 'check_output', mock_check_output)
+    monkeypatch.setattr(subprocess, 'Popen', mock_popen)
+
+    settings_manager.open_output_folder(tmp_path)
+
+    assert called['check'] == ['wslpath', '-w', str(tmp_path)]
+    assert called['popen'] == ['explorer.exe', 'C:\\temp\\folder']
+
+
+def test_open_log_folder_wsl(monkeypatch, tmp_path):
+    called = {}
+
+    monkeypatch.setattr(log_manager, '_is_wsl', lambda: True)
+    monkeypatch.setattr(log_manager, '_log_folder', str(tmp_path))
+    monkeypatch.setattr(log_manager.shutil, 'which', lambda cmd: 'explorer.exe' if cmd == 'explorer.exe' else None)
+
+    def mock_check_output(args):
+        called['check'] = args
+        return b'C:\\temp\\logs\n'
+
+    def mock_popen(args):
+        called['popen'] = args
+
+    monkeypatch.setattr(subprocess, 'check_output', mock_check_output)
+    monkeypatch.setattr(subprocess, 'Popen', mock_popen)
+
+    log_manager.open_log_folder()
+
+    assert called['check'] == ['wslpath', '-w', str(tmp_path)]
+    assert called['popen'] == ['explorer.exe', 'C:\\temp\\logs']

--- a/webui/eichi_utils/log_manager.py
+++ b/webui/eichi_utils/log_manager.py
@@ -283,7 +283,16 @@ def open_log_folder():
             print(translate("ログフォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             if _is_wsl() and shutil.which('explorer.exe'):
-                subprocess.Popen(['explorer.exe', folder_path])
+                win_path = folder_path
+                try:
+                    win_path = (
+                        subprocess.check_output(['wslpath', '-w', folder_path])
+                        .decode()
+                        .strip()
+                    )
+                except Exception:
+                    pass
+                subprocess.Popen(['explorer.exe', win_path])
                 print(translate("ログフォルダを開きました: {0}").format(folder_path))
             else:
                 opener = None
@@ -295,7 +304,11 @@ def open_log_folder():
                     subprocess.Popen([opener, folder_path])
                     print(translate("ログフォルダを開きました: {0}").format(folder_path))
                 else:
-                    print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+                    print(
+                        translate(
+                            "xdg-open/open が見つからないため自動でフォルダを開けません: {0}"
+                        ).format(folder_path)
+                    )
         else:
             print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
     except Exception as e:

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -130,7 +130,16 @@ def open_output_folder(folder_path):
             print(translate("フォルダを開きました: {0}").format(folder_path))
         elif os.name == 'posix':
             if _is_wsl() and shutil.which('explorer.exe'):
-                subprocess.Popen(['explorer.exe', folder_path])
+                win_path = folder_path
+                try:
+                    win_path = (
+                        subprocess.check_output(['wslpath', '-w', folder_path])
+                        .decode()
+                        .strip()
+                    )
+                except Exception:
+                    pass
+                subprocess.Popen(['explorer.exe', win_path])
                 print(translate("フォルダを開きました: {0}").format(folder_path))
             else:
                 opener = None
@@ -142,7 +151,11 @@ def open_output_folder(folder_path):
                     subprocess.Popen([opener, folder_path])
                     print(translate("フォルダを開きました: {0}").format(folder_path))
                 else:
-                    print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
+                    print(
+                        translate(
+                            "xdg-open/open が見つからないため自動でフォルダを開けません: {0}"
+                        ).format(folder_path)
+                    )
         else:
             print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
     except Exception as e:


### PR DESCRIPTION
## Summary
- convert output-folder opener to use `wslpath` on WSL before launching Explorer
- apply the same fix to log folder opener
- add tests ensuring WSL paths are converted to Windows format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68967a194b80832fbfb7db5bc8f504b5