### PR TITLE
Improve transformer cleanup and progress tracking

### DIFF
--- a/webui/eichi_utils/transformer_manager.py
+++ b/webui/eichi_utils/transformer_manager.py
@@ -382,3 +382,14 @@ class TransformerManager:
             traceback.print_exc()
             self.current_state['is_loaded'] = False
             return False
+
+    def dispose_transformer(self):
+        """Safely move transformer to CPU and reset state."""
+        if self.transformer is not None:
+            try:
+                self.transformer.to('cpu')
+                print(translate("transformerをCPUに移動しました"))
+            except Exception:
+                pass
+            self.transformer = None
+        self.current_state['is_loaded'] = False


### PR DESCRIPTION
## Summary
- Fix lora cache setting NameError by defaulting to `False`
- Remove duplicated global variable block and enforce resolution alignment
- Add safe FanoutQueue closing, transformer disposal API, and conditional RoPE batching with accurate progress counters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bfe2e0d0832f8c7ea4e53237ad9d