### PR TITLE
Fix WSL input folder open support

### DIFF
--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3652,25 +3652,9 @@ with block:
                         # 画像ファイルリストを更新
                         get_image_queue_files()
 
-                        # プラットフォームに応じてフォルダを開く
                         try:
-                            if os.name == 'nt':  # Windows
-                                os.startfile(input_dir)
-                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                            elif os.name == 'posix':
-                                opener = None
-                                if sys.platform == 'darwin' and shutil.which('open'):
-                                    opener = 'open'
-                                else:
-                                    opener = shutil.which('xdg-open') or shutil.which('open')
-                                if opener:
-                                    subprocess.Popen([opener, input_dir])
-                                    print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                                else:
-                                    print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
-                            else:
-                                print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
-                            return translate("設定を保存しました")
+                            open_output_folder(input_dir)
+                            return translate("設定を保存し、入力フォルダを開きました")
                         except Exception as e:
                             error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                             print(error_msg)

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4712,25 +4712,9 @@ with block:
                     # 画像ファイルリストを更新
                     get_image_queue_files()
 
-                    # プラットフォームに応じてフォルダを開く
                     try:
-                        if os.name == 'nt':  # Windows
-                            os.startfile(input_dir)
-                            print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                        elif os.name == 'posix':
-                            opener = None
-                            if sys.platform == 'darwin' and shutil.which('open'):
-                                opener = 'open'
-                            else:
-                                opener = shutil.which('xdg-open') or shutil.which('open')
-                            if opener:
-                                subprocess.Popen([opener, input_dir])
-                                print(translate("入力フォルダを開きました: {0}").format(input_dir))
-                            else:
-                                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(input_dir))
-                        else:
-                            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(input_dir))
-                        return translate("設定を保存しました")
+                        open_output_folder(input_dir)
+                        return translate("設定を保存し、入力フォルダを開きました")
                     except Exception as e:
                         error_msg = translate("フォルダを開けませんでした: {0}").format(str(e))
                         print(error_msg)

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -636,30 +636,8 @@ HunyuanVideoTransformer3DModelPacked = spinner_while_running(
 # フォルダを開く関数
 def open_folder(folder_path):
     """指定されたフォルダをOSに依存せず開く"""
-    if not os.path.exists(folder_path):
-        os.makedirs(folder_path, exist_ok=True)
-        print(translate("フォルダを作成しました: {0}").format(folder_path))
-
     try:
-        if os.name == 'nt':  # Windows環境
-            try:
-                os.startfile(folder_path)
-            except Exception:
-                subprocess.Popen(['explorer', folder_path])
-            print(translate("フォルダを開きました: {0}").format(folder_path))
-        elif os.name == 'posix':
-            opener = None
-            if sys.platform == 'darwin' and shutil.which('open'):
-                opener = 'open'
-            else:
-                opener = shutil.which('xdg-open') or shutil.which('open')
-            if opener:
-                subprocess.Popen([opener, folder_path])
-                print(translate("フォルダを開きました: {0}").format(folder_path))
-            else:
-                print(translate("xdg-open/open が見つからないため自動でフォルダを開けません: {0}").format(folder_path))
-        else:
-            print(translate("このOSではフォルダを自動で開く機能はサポートされていません: {0}").format(folder_path))
+        open_output_folder(folder_path)
         return True
     except Exception as e:
         print(translate("フォルダを開く際にエラーが発生しました: {0}").format(e))


### PR DESCRIPTION
## Summary
- reuse cross-platform folder opening helper for queue input and reference folders
- ensure queue input folder saves settings and opens across WSL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896d4383c18832f8819eada34f5f19c