### PR TITLE
fix: refine stop controls

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -429,7 +429,6 @@ def _stream_job_to_ui(ctx: JobContext):
                 stop_after_current = False
                 stop_after_step = False
                 globals()['last_stop_mode'] = stop_state.get()
-                last_stop_mode = globals()['last_stop_mode']
                 stop_state.clear()
                 progress_summary = f"参考画像 {progress_ref_idx}/{progress_ref_total} ,イメージ {progress_img_idx}/{progress_img_total}"
                 # 即時停止の最終表示を正しく中断扱いにする
@@ -2961,6 +2960,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         print(translate("指定されたSEED値 {0} を使用します。").format(seed))
         # UI更新（値は変更しない）
         end_enabled, stop_current_enabled, stop_step_enabled, stop_current_label, stop_step_label = _compute_stop_controls(True)
+        globals()['current_seed'] = seed
         yield (
             gr.skip(),
             None,

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -428,7 +428,8 @@ def _stream_job_to_ui(ctx: JobContext):
             elif flag == 'end':
                 stop_after_current = False
                 stop_after_step = False
-                last_stop_mode = stop_state.get()
+                globals()['last_stop_mode'] = stop_state.get()
+                last_stop_mode = globals()['last_stop_mode']
                 stop_state.clear()
                 progress_summary = f"参考画像 {progress_ref_idx}/{progress_ref_total} ,イメージ {progress_img_idx}/{progress_img_total}"
                 # 即時停止の最終表示を正しく中断扱いにする
@@ -2902,6 +2903,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
     
     # 生成開始直後の初期UI（ボタン状態・ラベルを _compute_stop_controls に合わせる）
     end_enabled, stop_current_enabled, stop_step_enabled, stop_current_label, stop_step_label = _compute_stop_controls(True)
+    globals()['current_seed'] = seed  # ランダムで後から変えてもここで初期値は同期
     yield (
         gr.skip(),
         None,

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2008,10 +2008,13 @@ def _worker_impl(ctx: JobContext, input_image, prompt, n_prompt, seed, steps, cf
                 except Exception as e:
                     import traceback
                     traceback.print_exc()
+                    # UIにエラー発生を知らせ、ジョブを確実に停止
                     try:
-                        ctx.bus.publish(('progress', (None, translate('プレビュー生成中にエラーが発生しました'), '')))
+                        ctx.bus.publish(('progress', (None, translate('サンプリング中にエラーが発生しました'), '')))
                     except Exception:
                         pass
+                    # サンプラ側に中断を明示
+                    return {'user_interrupt': True}
             
             # 異常な次元数を持つテンソルを処理
             try:
@@ -3255,6 +3258,7 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
             return
         except Exception as e:
             import traceback
+            traceback.print_exc()
             # UIをリセット
             stop_state.clear()
             end_enabled, stop_current_enabled, stop_step_enabled, stop_current_label, stop_step_label = _compute_stop_controls(False)


### PR DESCRIPTION
## Summary
- track last stop mode and clear stop state for consistent labels across reconnects and job completion
- reuse stop control helper in seed selection, error handling and streaming teardown, replacing placeholder updates with skips
- publish preview callback errors to UI and use neutral stop logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999468df38832fad4d0e1f9f29619b