### PR TITLE
Integrate modal viewer assets into FramePack web UIs

### DIFF
--- a/webui/eichi_utils/modal.css
+++ b/webui/eichi_utils/modal.css
@@ -1,0 +1,36 @@
+#orig_size_modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+}
+#orig_size_modal.visible {
+  visibility: visible;
+  opacity: 1;
+}
+#orig_size_modal img {
+  max-width: 90%;
+  max-height: 90%;
+}
+#orig_size_close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 24px;
+  background: transparent;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+.orig-size-btn {
+  margin-right: 0.5rem;
+}

--- a/webui/eichi_utils/modal.js
+++ b/webui/eichi_utils/modal.js
@@ -1,0 +1,27 @@
+function setupOrigSize(){
+  const modal=document.getElementById('orig_size_modal');
+  const imgElem=document.getElementById('orig_size_img');
+  const closeBtn=document.getElementById('orig_size_close');
+  closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
+  function addButtons(){
+    document.querySelectorAll('[data-testid="image"]').forEach(div=>{
+      if(div.querySelector('.orig-size-btn')) return;
+      const img=div.querySelector('img');
+      const toolbar=div.querySelector('div.flex');
+      if(!img||!toolbar) return;
+      const btn=document.createElement('button');
+      btn.innerText='原寸';
+      btn.className='orig-size-btn';
+      btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
+      toolbar.insertBefore(btn, toolbar.firstChild);
+    });
+  }
+  addButtons();
+  const obs=new MutationObserver(addButtons);
+  obs.observe(document.body,{childList:true,subtree:true});
+}
+if(document.readyState !== 'loading'){
+  setupOrigSize();
+} else {
+  window.addEventListener('load', setupOrigSize);
+}

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -3320,41 +3320,14 @@ block = gr.Blocks(css=css).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-eichi</span></h1>')
 
-    # 原寸大表示用モーダルとボタン追加スクリプト
+    # 原寸大表示用モーダル (外部JS/CSS読み込み)
     gr.HTML("""
+    <link rel='stylesheet' href='file=eichi_utils/modal.css'>
     <div id='orig_size_modal'>
       <button id='orig_size_close'>×</button>
       <img id='orig_size_img'>
     </div>
-    <script>
-    function setupOrigSize(){
-      const modal=document.getElementById('orig_size_modal');
-      const imgElem=document.getElementById('orig_size_img');
-      const closeBtn=document.getElementById('orig_size_close');
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
-          if(div.querySelector('.orig-size-btn')) return;
-          const img=div.querySelector('img');
-          const toolbar=div.querySelector('div.flex');
-          if(!img||!toolbar) return;
-          const btn=document.createElement('button');
-          btn.innerText='原寸';
-          btn.className='orig-size-btn';
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, toolbar.firstChild);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      obs.observe(document.body,{childList:true,subtree:true});
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
+    <script src='file=eichi_utils/modal.js'></script>
     """)
 
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4499,41 +4499,14 @@ block = gr.Blocks(css=css).queue()
 with block:
     gr.HTML('<h1>FramePack<span class="title-suffix">-<s>eichi</s> F1</span></h1>')
 
-    # 原寸大表示用モーダルとボタン追加スクリプト
+    # 原寸大表示用モーダル (外部JS/CSS読み込み)
     gr.HTML("""
+    <link rel='stylesheet' href='file=eichi_utils/modal.css'>
     <div id='orig_size_modal'>
       <button id='orig_size_close'>×</button>
       <img id='orig_size_img'>
     </div>
-    <script>
-    function setupOrigSize(){
-      const modal=document.getElementById('orig_size_modal');
-      const imgElem=document.getElementById('orig_size_img');
-      const closeBtn=document.getElementById('orig_size_close');
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
-          if(div.querySelector('.orig-size-btn')) return;
-          const img=div.querySelector('img');
-          const toolbar=div.querySelector('div.flex');
-          if(!img||!toolbar) return;
-          const btn=document.createElement('button');
-          btn.innerText='原寸';
-          btn.className='orig-size-btn';
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, toolbar.firstChild);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      obs.observe(document.body,{childList:true,subtree:true});
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
+    <script src='file=eichi_utils/modal.js'></script>
     """)
 
     # 一番上の行に「生成モード、セクションフレームサイズ、オールパディング、動画長」を配置

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -3077,41 +3077,14 @@ with block:
     # eichiと同じ半透明度スタイルを使用
     gr.HTML('<h1>FramePack<span class="title-suffix">-oichi</span></h1>')
 
-    # 原寸大表示用モーダルとボタン追加スクリプト
+    # 原寸大表示用モーダル (外部JS/CSS読み込み)
     gr.HTML("""
+    <link rel='stylesheet' href='file=eichi_utils/modal.css'>
     <div id='orig_size_modal'>
       <button id='orig_size_close'>×</button>
       <img id='orig_size_img'>
     </div>
-    <script>
-    function setupOrigSize(){
-      const modal=document.getElementById('orig_size_modal');
-      const imgElem=document.getElementById('orig_size_img');
-      const closeBtn=document.getElementById('orig_size_close');
-      closeBtn.addEventListener('click',()=>{modal.classList.remove('visible');imgElem.src='';});
-      function addButtons(){
-        document.querySelectorAll('[data-testid="image"]').forEach(div=>{
-          if(div.querySelector('.orig-size-btn')) return;
-          const img=div.querySelector('img');
-          const toolbar=div.querySelector('div.flex');
-          if(!img||!toolbar) return;
-          const btn=document.createElement('button');
-          btn.innerText='原寸';
-          btn.className='orig-size-btn';
-          btn.addEventListener('click',()=>{imgElem.src=img.src;modal.classList.add('visible');});
-          toolbar.insertBefore(btn, toolbar.firstChild);
-        });
-      }
-      addButtons();
-      const obs=new MutationObserver(addButtons);
-      obs.observe(document.body,{childList:true,subtree:true});
-    }
-    if(document.readyState !== 'loading'){
-      setupOrigSize();
-    } else {
-      window.addEventListener('load', setupOrigSize);
-    }
-    </script>
+    <script src='file=eichi_utils/modal.js'></script>
     """)
     
     # 初期化時にtransformerの状態確認は行わない（必要時に遅延ロード）


### PR DESCRIPTION
## Summary
- add reusable `modal.js` and `modal.css` to `eichi_utils`
- load the modal assets in `oneframe_ichi.py`, `endframe_ichi.py`, and `endframe_ichi_f1.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e117c7e44832f8cdf632d78dad284