### PR TITLE
Show version in oneframe_ichi startup and UI

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -1,9 +1,12 @@
 
 import os
 import traceback
+
+__version__ = "1.9.5.2"
+
 # 即座に起動しているファイル名をまずは出力して、画面に応答を表示する
 print(f"\n------------------------------------------------------------")
-print(f"{os.path.basename(__file__)} : Starting....")
+print(f"{os.path.basename(__file__)} : version {__version__} Starting....")
 print(f"------------------------------------------------------------\n")
 
 # 進捗バーやスピナーと協調するスレッドセーフなprint文を有効化
@@ -5493,7 +5496,9 @@ with block:
         queue=False,
     )
     
-    gr.HTML(f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")}</div>')
+    gr.HTML(
+        f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")} version {__version__}</div>'
+    )
 
 block.launch(
     server_name=args.server,


### PR DESCRIPTION
## Summary
- define a __version__ constant for oneframe_ichi
- show version during startup and in web UI header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a30461d3c8832fb8f2b29b5282500d