### PR TITLE
Display version in single-frame interface

### DIFF
--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -1,8 +1,12 @@
 
 import os
+import traceback
+
+__version__ = "1.9.5.2"
+
 # 即座に起動しているファイル名をまずは出力して、画面に応答を表示する
 print(f"\n------------------------------------------------------------")
-print(f"{os.path.basename(__file__)} : Starting....")
+print(f"{os.path.basename(__file__)} : version {__version__} Starting....")
 print(f"------------------------------------------------------------\n")
 
 # 進捗バーやスピナーと協調するスレッドセーフなprint文を有効化
@@ -5224,7 +5228,9 @@ with block:
         queue=False,
     )
     
-    gr.HTML(f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")}</div>')
+    gr.HTML(
+        f'<div style="text-align:center; margin-top:20px;">{translate("FramePack 単一フレーム生成版")} version {__version__}</div>'
+    )
 
 block.launch(
     server_name=args.server,


### PR DESCRIPTION
## Summary
- Add `__version__` constant to `oneframe_ichi.py`
- Show version info in startup log and UI HTML message

## Testing
- `python -m py_compile webui/oneframe_ichi.py`


------
https://chatgpt.com/codex/tasks/task_e_68a30dd20a90832fa1e8d0f6c1a23e0c