### PR TITLE
Persist LoRA cache checkbox in saved settings

### DIFF
--- a/tests/test_save_app_settings_endframe.py
+++ b/tests/test_save_app_settings_endframe.py
@@ -1,0 +1,39 @@
+import importlib.util
+import json
+import sys
+import types
+
+# fake locales module for translation
+locales = types.ModuleType('locales')
+locales.i18n_extended = types.ModuleType('locales.i18n_extended')
+locales.i18n_extended.translate = lambda x: x
+sys.modules['locales'] = locales
+sys.modules['locales.i18n_extended'] = locales.i18n_extended
+
+spec = importlib.util.spec_from_file_location(
+    'settings_manager', 'webui/eichi_utils/settings_manager.py')
+sm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sm)
+
+
+def test_save_app_settings_eichi(tmp_path, monkeypatch):
+    settings_file = tmp_path / 'app_settings.json'
+    monkeypatch.setattr(sm, 'get_settings_file_path', lambda: settings_file)
+    sm.initialize_settings()
+
+    sm.save_app_settings({'resolution': 640, 'lora_cache': True})
+
+    data = json.loads(settings_file.read_text())
+    assert data['app_settings_eichi']['lora_cache'] is True
+
+
+def test_save_app_settings_f1(tmp_path, monkeypatch):
+    settings_file = tmp_path / 'app_settings.json'
+    monkeypatch.setattr(sm, 'get_settings_file_path', lambda: settings_file)
+    sm.initialize_settings()
+
+    sm.save_app_settings_f1({'resolution': 640, 'lora_cache': True})
+
+    data = json.loads(settings_file.read_text())
+    assert data['app_settings_f1']['lora_cache'] is True
+

--- a/webui/eichi_utils/settings_manager.py
+++ b/webui/eichi_utils/settings_manager.py
@@ -208,6 +208,7 @@ def get_default_app_settings(current_lang="ja"):
         
         # パフォーマンス設定
         "use_teacache": True,
+        "lora_cache": False,
         "use_prompt_cache": True,
         "gpu_memory_preservation": 6,
         "use_vae_cache": False,
@@ -253,6 +254,7 @@ def get_default_app_settings_f1(current_lang="ja"):
         
         # パフォーマンス設定
         "use_teacache": True,
+        "lora_cache": False,
         "gpu_memory_preservation": 6,
         
         # 詳細設定
@@ -402,7 +404,7 @@ def save_app_settings_f1(app_settings):
     
     # 保存すべきキーのみを含める（許可リスト方式）
     allowed_keys = [
-        'resolution', 'mp4_crf', 'steps', 'cfg', 'use_teacache',
+        'resolution', 'mp4_crf', 'steps', 'cfg', 'use_teacache', 'lora_cache',
         'gpu_memory_preservation', 'gs', 'image_strength',
         'keep_section_videos', 'save_section_frames', 'save_tensor_data',
         'frame_save_mode', 'save_settings_on_start', 'alarm_on_completion',

--- a/webui/endframe_ichi.py
+++ b/webui/endframe_ichi.py
@@ -6048,6 +6048,7 @@ with block:
                 steps_val,
                 cfg_val,
                 use_teacache_val,
+                lora_cache_val,
                 gpu_memory_preservation_val,
                 gs_val,
                 use_all_padding_val,
@@ -6076,6 +6077,7 @@ with block:
                     "cfg": cfg_val,
                     # パフォーマンス設定
                     "use_teacache": use_teacache_val,
+                    "lora_cache": lora_cache_val,
                     "gpu_memory_preservation": gpu_memory_preservation_val,
                     "use_vae_cache": use_vae_cache_val,
                     # 詳細設定
@@ -6162,6 +6164,7 @@ with block:
                 
                 # パフォーマンス設定
                 updates.append(gr.update(value=default_settings["use_teacache"]))
+                updates.append(gr.update(value=default_settings.get("lora_cache", False)))
                 updates.append(gr.update(value=default_settings["gpu_memory_preservation"]))
                 updates.append(gr.update(value=default_settings.get("use_vae_cache", False)))
                 
@@ -6184,31 +6187,34 @@ with block:
                 # 自動保存設定
                 updates.append(gr.update(value=default_settings.get("save_settings_on_start", False)))
                 
-                # アラーム設定 (17番目の要素)
+                # アラーム設定 (18番目の要素)
                 updates.append(gr.update(value=default_settings.get("alarm_on_completion", True)))
-                
-                # ログ設定 (18番目と19番目の要素)
+
+                # ログ設定 (19番目と20番目の要素)
                 # ログ設定は固定値を使用 - 絶対に文字列とbooleanを使用
-                updates.append(gr.update(value=False))  # log_enabled (18)
-                updates.append(gr.update(value="logs"))  # log_folder (19)
+                updates.append(gr.update(value=False))  # log_enabled (19)
+                updates.append(gr.update(value="logs"))  # log_folder (20)
                 
-                # ステータスメッセージ (20番目の要素)
+                # ステータスメッセージ (21番目の要素)
                 updates.append(translate("🔄 設定をデフォルト値にリセットしました"))
-                
+
                 # ログ設定をアプリケーションに適用
                 default_log_settings = {
                     "log_enabled": False,
                     "log_folder": "logs"
                 }
-                
+
                 # 設定ファイルを更新
                 all_settings = load_settings()
                 all_settings['log_settings'] = default_log_settings
                 save_settings(all_settings)
-                
+
                 # ログ設定を適用 (既存のログファイルを閉じて、設定に従って再設定)
                 disable_logging()  # 既存のログを閉じる
-                
+
+                # LoRAキャッシュをデフォルト値に合わせる
+                lora_state_cache.set_cache_enabled(default_settings.get("lora_cache", False))
+
                 return updates
             
             # イベントハンドラの登録
@@ -6220,6 +6226,7 @@ with block:
                     steps,
                     cfg,
                     use_teacache,
+                    lora_cache_checkbox,
                     gpu_memory_preservation,
                     gs,
                     use_all_padding,
@@ -6238,7 +6245,7 @@ with block:
                 outputs=[settings_status]
             )
             
-            # リセットボタンのクリックイベント (20出力)
+            # リセットボタンのクリックイベント (21出力)
             reset_settings_btn.click(
                 fn=reset_app_settings_handler,
                 inputs=[],
@@ -6248,21 +6255,22 @@ with block:
                     steps,                # 3
                     cfg,                  # 4
                     use_teacache,         # 5
-                    gpu_memory_preservation, # 6
-                    use_vae_cache,        # 7
-                    gs,                   # 8
-                    use_all_padding,      # 9
-                    all_padding_value,    # 10
-                    end_frame_strength,   # 11
-                    keep_section_videos,  # 12
-                    save_section_frames,  # 13
-                    save_tensor_data,     # 14
-                    frame_save_mode,      # 15
-                    save_settings_on_start, # 16
-                    alarm_on_completion,  # 17
-                    log_enabled,          # 18
-                    log_folder,           # 19
-                    settings_status       # 20
+                    lora_cache_checkbox,  # 6
+                    gpu_memory_preservation, # 7
+                    use_vae_cache,        # 8
+                    gs,                   # 9
+                    use_all_padding,      # 10
+                    all_padding_value,    # 11
+                    end_frame_strength,   # 12
+                    keep_section_videos,  # 13
+                    save_section_frames,  # 14
+                    save_tensor_data,     # 15
+                    frame_save_mode,      # 16
+                    save_settings_on_start, # 17
+                    alarm_on_completion,  # 18
+                    log_enabled,          # 19
+                    log_folder,           # 20
+                    settings_status       # 21
                 ]
             )
 
@@ -6390,6 +6398,7 @@ with block:
                 "cfg": cfg,
                 # パフォーマンス設定
                 "use_teacache": use_teacache,
+                "lora_cache": lora_state_cache.cache_enabled,
                 "gpu_memory_preservation": gpu_memory_preservation,
                 "use_vae_cache": use_vae_cache,
                 # 詳細設定

--- a/webui/endframe_ichi_f1.py
+++ b/webui/endframe_ichi_f1.py
@@ -4000,6 +4000,7 @@ def process(input_image, prompt, n_prompt, seed, total_second_length, latent_win
                 "steps": steps,
                 "cfg": cfg,
                 "use_teacache": use_teacache,
+                "lora_cache": lora_state_cache.cache_enabled,
                 "gpu_memory_preservation": gpu_memory_preservation,
                 "gs": gs,
                 "image_strength": image_strength,
@@ -5855,6 +5856,7 @@ with block:
                 cfg_val,
                 # Performance settings
                 use_teacache_val,
+                lora_cache_val,
                 gpu_memory_preservation_val,
                 # Detail settings
                 gs_val,
@@ -5886,6 +5888,7 @@ with block:
                     "cfg": cfg_val,
                     # パフォーマンス設定
                     "use_teacache": use_teacache_val,
+                    "lora_cache": lora_cache_val,
                     "gpu_memory_preservation": gpu_memory_preservation_val,
                     # 詳細設定
                     "gs": gs_val,
@@ -5966,21 +5969,22 @@ with block:
                 updates.append(gr.update(value=default_settings.get("steps", 25)))  # 3
                 updates.append(gr.update(value=default_settings.get("cfg", 1.0)))  # 4
                 updates.append(gr.update(value=default_settings.get("use_teacache", True)))  # 5
-                updates.append(gr.update(value=default_settings.get("gpu_memory_preservation", 6)))  # 6
-                updates.append(gr.update(value=default_settings.get("gs", 10)))  # 7
+                updates.append(gr.update(value=default_settings.get("lora_cache", False)))  # 6
+                updates.append(gr.update(value=default_settings.get("gpu_memory_preservation", 6)))  # 7
+                updates.append(gr.update(value=default_settings.get("gs", 10)))  # 8
                 # F1独自
-                updates.append(gr.update(value=default_settings.get("image_strength", 1.0)))  # 8
-                updates.append(gr.update(value=default_settings.get("keep_section_videos", False)))  # 9
-                updates.append(gr.update(value=default_settings.get("save_section_frames", False)))  # 10
-                updates.append(gr.update(value=default_settings.get("save_tensor_data", False)))  # 11
-                updates.append(gr.update(value=default_settings.get("frame_save_mode", translate("保存しない"))))  # 12
-                updates.append(gr.update(value=default_settings.get("save_settings_on_start", False)))  # 13
-                updates.append(gr.update(value=default_settings.get("alarm_on_completion", True)))  # 14
-                
-                # ログ設定 (15番目め16番目の要素)
+                updates.append(gr.update(value=default_settings.get("image_strength", 1.0)))  # 9
+                updates.append(gr.update(value=default_settings.get("keep_section_videos", False)))  # 10
+                updates.append(gr.update(value=default_settings.get("save_section_frames", False)))  # 11
+                updates.append(gr.update(value=default_settings.get("save_tensor_data", False)))  # 12
+                updates.append(gr.update(value=default_settings.get("frame_save_mode", translate("保存しない"))))  # 13
+                updates.append(gr.update(value=default_settings.get("save_settings_on_start", False)))  # 14
+                updates.append(gr.update(value=default_settings.get("alarm_on_completion", True)))  # 15
+
+                # ログ設定 (16番目め17番目の要素)
                 # ログ設定は固定値を使用 - 絶対に文字列とbooleanを使用
-                updates.append(gr.update(value=False))  # log_enabled (15)
-                updates.append(gr.update(value="logs"))  # log_folder (16)
+                updates.append(gr.update(value=False))  # log_enabled (16)
+                updates.append(gr.update(value="logs"))  # log_folder (17)
                 
                 # ログ設定をアプリケーションに適用
                 default_log_settings = {
@@ -5988,20 +5992,23 @@ with block:
                     "log_folder": "logs"
                 }
 
-                # CONFIG QUEUE設定 - NEW (17番目の要素)
-                updates.append(gr.update(value=default_settings.get("add_timestamp_to_config", True)))  # 17
+                # CONFIG QUEUE設定 - NEW (18番目の要素)
+                updates.append(gr.update(value=default_settings.get("add_timestamp_to_config", True)))  # 18
                 
                 # 設定ファイルを更新
                 all_settings = load_settings()
                 all_settings['log_settings'] = default_log_settings
                 save_settings(all_settings)
-                
+
                 # ログ設定を適用 (既存のログファイルを閉じて、設定に従って再設定)
                 disable_logging()  # 既存のログを閉じる
-                
-                # 設定状態メッセージ (18番目の要素)
+
+                # LoRAキャッシュをデフォルト値に合わせる
+                lora_state_cache.set_cache_enabled(default_settings.get("lora_cache", False))
+
+                # 設定状態メッセージ (19番目の要素)
                 updates.append(translate("設定をデフォルトに戻しました"))
-                
+
                 return updates
 
     # 実行前のバリデーション関数
@@ -6234,6 +6241,7 @@ with block:
             steps,
             cfg,
             use_teacache,
+            lora_cache_checkbox,
             gpu_memory_preservation,
             gs,
             image_strength,
@@ -6262,19 +6270,20 @@ with block:
             steps,                # 3
             cfg,                  # 4
             use_teacache,         # 5
-            gpu_memory_preservation, # 6
-            gs,                   # 7
-            image_strength,       # 8
-            keep_section_videos,  # 9
-            save_section_frames,  # 10
-            save_tensor_data,     # 11
-            frame_save_mode,      # 12
-            save_settings_on_start, # 13
-            alarm_on_completion,  # 14
-            log_enabled,          # 15
-            log_folder,           # 16
-            config_queue_components['add_timestamp_to_config'], # 17 - NEW OUTPUT
-            settings_status       # 18
+            lora_cache_checkbox,  # 6
+            gpu_memory_preservation, # 7
+            gs,                   # 8
+            image_strength,       # 9
+            keep_section_videos,  #10
+            save_section_frames,  #11
+            save_tensor_data,     #12
+            frame_save_mode,      #13
+            save_settings_on_start, #14
+            alarm_on_completion,  #15
+            log_enabled,          #16
+            log_folder,           #17
+            config_queue_components['add_timestamp_to_config'], #18 - NEW OUTPUT
+            settings_status       #19
         ]
     )
 

--- a/webui/oneframe_ichi.py
+++ b/webui/oneframe_ichi.py
@@ -2887,7 +2887,12 @@ def process(input_image, prompt, n_prompt, seed, steps, cfg, gs, rs, gpu_memory_
         print(translate("=== 現在の設定を自動保存します ==="))
         # 現在のUIの値を収集してアプリケーション設定として保存
         # Gradioオブジェクトから値を取得（直接値が渡る場合も考慮）
-        lora_cache_val = False
+        # lora_cache_checkbox が存在する場合はその値を取得し、
+        # 存在しない場合は lora_state_cache の状態を使用する
+        try:
+            lora_cache_val = bool(lora_cache_checkbox.value)
+        except Exception:
+            lora_cache_val = getattr(lora_state_cache, "cache_enabled", False)
 
         # Gradioオブジェクトの値を正規化
         log_enabled_val = log_enabled


### PR DESCRIPTION
## Summary
- preserve the “reuse optimized dictionary” checkbox during auto-save for one-frame and end-frame modes
- allow LoRA cache setting to be saved/restored with manual configuration saves
- add defaults and whitelist entries for LoRA cache and tests covering its persistence

## Testing
- `pytest tests/test_save_app_settings_oichi.py tests/test_save_app_settings_endframe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baee93f230832fb04e8a5f16ca08d7